### PR TITLE
fix(ci): use pnpm 10 in update-datum-templates workflow

### DIFF
--- a/.github/workflows/update-datum-email-templates.yml
+++ b/.github/workflows/update-datum-email-templates.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Install dependencies
         working-directory: email-templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "email-templates",
   "version": "1.0.0",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "build": "email build",
     "dev": "email dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-allowBuilds:
-  esbuild: true
-  sharp: true
+onlyBuiltDependencies:
+  - esbuild
+  - sharp


### PR DESCRIPTION
The workflow pinned pnpm 8, but the repo migrated to pnpm 10 conventions
in PR #13: the new pnpm-workspace.yaml omits the 'packages' field (valid
under pnpm 10, where the file doubles as a settings file) and the lockfile
is lockfileVersion 9.0. pnpm 8 rejects both, failing 'pnpm install' with
ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION (packages field missing or empty).
Bumping CI to pnpm 10 matches the local toolchain and the lockfile.