### PR TITLE
fix(ci): align pnpm tooling so the update-datum-templates workflow passes

### DIFF
--- a/.github/workflows/update-datum-email-templates.yml
+++ b/.github/workflows/update-datum-email-templates.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Install dependencies
         working-directory: email-templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "email-templates",
   "version": "1.0.0",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "build": "email build",
     "dev": "email dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-allowBuilds:
-  esbuild: true
-  sharp: true
+onlyBuiltDependencies:
+  - esbuild
+  - sharp


### PR DESCRIPTION
## Summary

The **Update Datum Email Templates** workflow failed on the merge of #13 with:

```
ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION  packages field missing or empty
```

#13 migrated the repo to **pnpm 10** conventions — a `pnpm-workspace.yaml` without a `packages:` field (valid under pnpm 10, where that file doubles as a settings file) and a regenerated lockfile at `lockfileVersion: '9.0'`. But the workflow still installs **pnpm 8**, which requires `packages:` in any workspace file and can't read lockfile 9.0, so `pnpm install` aborts immediately. It worked locally (pnpm 10.33.0) but broke in CI — a local-vs-CI version skew.

## Changes

- **Bump pnpm to 10** in `.github/workflows/update-datum-email-templates.yml` to match the local toolchain and the lockfile (the actual fix for the failing run).
- **Replace the invalid `allowBuilds` key with `onlyBuiltDependencies`** in `pnpm-workspace.yaml`. `allowBuilds` is not a recognized pnpm setting and was silently ignored, so `esbuild`/`sharp` build scripts were never actually allowlisted.
- **Pin `packageManager` to `pnpm@10.33.0`** in `package.json` so CI and local environments resolve the same pnpm version and can't drift again.

## Test plan

- [x] `pnpm install` with pnpm 10.33.0 succeeds locally; `esbuild` and `sharp` build scripts now run (`sharp install: Done`, `esbuild postinstall: Done`)
- [x] `pnpm-lock.yaml` unchanged by the config edits
- [ ] On merge, the **Update Datum Email Templates** workflow installs pnpm 10 and completes `pnpm install` / `pnpm generate:all`

ref: #13