### PR TITLE
chore(ci): mint datum token via GitHub App and add Renovate

### DIFF
--- a/.github/workflows/update-datum-email-templates.yml
+++ b/.github/workflows/update-datum-email-templates.yml
@@ -14,14 +14,26 @@ on:
 jobs:
   update-datum-templates:
     runs-on: ubuntu-latest
+    # The workflow's own GITHUB_TOKEN only reads this repo; all writes to the
+    # datum repo go through the short-lived, datum-scoped GitHub App token below.
     permissions:
-      contents: write
-      pull-requests: write
-    
+      contents: read
+
     # Only run if PR was merged (not just closed)
     if: github.event.pull_request.merged == true
-    
+
     steps:
+      # Mint a short-lived (~1h), datum-scoped token from the GitHub App at run
+      # time, instead of storing a long-lived PAT. Auto-expires when the job ends.
+      - name: Generate datum repo token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.DATUM_PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.DATUM_PROJECT_AUTOMATION_PRIVATE_KEY }}
+          owner: datum-cloud
+          repositories: datum
+
       - name: Checkout email-templates repo
         uses: actions/checkout@v4
         with:
@@ -65,7 +77,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.DATUM_REPO }}
-          token: ${{ secrets.DATUM_REPO_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: datum
           fetch-depth: 0
 
@@ -120,7 +132,7 @@ jobs:
         if: steps.check-changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.DATUM_REPO_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: datum
           commit-message: |
             chore: update email templates and kustomization.yaml from email-templates repo

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security", "renovate"]
+  },
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "labels": ["renovate"],
+      "matchPackageNames": ["/.*/"]
+    },
+    {
+      "matchCategories": ["security"],
+      "prPriority": 10
+    }
+  ]
+}


### PR DESCRIPTION
- Replace the cross-repo PAT/GITHUB_TOKEN fallback in the datum-sync workflow
  with a short-lived, datum-scoped token minted at runtime via the
  DATUM_PROJECT_AUTOMATION GitHub App (actions/create-github-app-token@v3)
- Drop the workflow's own GITHUB_TOKEN to contents: read (least privilege);
  all datum writes go through the App token
- Add renovate.json (based on cloud-portal's config) to keep dependencies
  current: config:recommended + GitHub Action digest pinning, OSV +
  vulnerability alerts with security PR prioritization
