### PR TITLE
Add a one-click release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,17 @@
-name: Cut Release
+name: Publish New Version
 
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to release, e.g. 1.2.0 (no leading v)'
+      bump:
+        description: 'How big is this update?'
         required: true
-        type: string
+        type: choice
+        default: patch
+        options:
+          - patch # small fixes, content tweaks
+          - minor # new templates, notable changes
+          - major # breaking changes to template variables/structure
 
 jobs:
   release:
@@ -16,17 +21,31 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
-      - name: Validate version format
+      - name: Compute next version
+        id: version
         run: |
-          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Version must be in the form X.Y.Z (no leading v), got '${{ inputs.version }}'"
-            exit 1
+          LATEST=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          if [ -z "${LATEST}" ]; then
+            NEXT="v0.1.0"
+          else
+            IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST#v}"
+            case "${{ inputs.bump }}" in
+              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+              patch) PATCH=$((PATCH + 1)) ;;
+            esac
+            NEXT="v${MAJOR}.${MINOR}.${PATCH}"
           fi
+          echo "Previous version: ${LATEST:-none}"
+          echo "Next version: ${NEXT}"
+          echo "tag=${NEXT}" >> "$GITHUB_OUTPUT"
 
       - name: Create release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: v${{ inputs.version }}
+          tag_name: ${{ steps.version.outputs.tag }}
           target_commitish: main
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Cut Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 1.2.0 (no leading v)'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must be in the form X.Y.Z (no leading v), got '${{ inputs.version }}'"
+            exit 1
+          fi
+
+      - name: Create release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: v${{ inputs.version }}
+          target_commitish: main
+          generate_release_notes: true


### PR DESCRIPTION
## What this does

Adds a `workflow_dispatch` "Cut Release" workflow — give it a version number, it tags `vX.Y.Z` and publishes a GitHub release. The existing publish workflow already triggers on `release: published`, so this is the missing piece to get real semver-tagged bundles instead of only branch-build tags.

## Why

Right now infra's preview/production pins ([infra#3504](https://github.com/datum-cloud/infra/pull/3504)) point at a stopgap branch-build tag because there's nothing else to pin to. This gives us a repeatable way to cut a version whenever we're ready to promote.

## Sequencing

No dependencies — safe to merge independently of the other open PRs. Once merged, cutting a `v0.1.0` release updates infra#3504's pins from the stopgap tag to a real one.

Part of #18
