### PR TITLE
Restore suspicious-signin greeting spacing

### DIFF
--- a/config/email-templates/usersuspicious-emailtemplate.yaml
+++ b/config/email-templates/usersuspicious-emailtemplate.yaml
@@ -89,7 +89,7 @@ spec:
                             <tr>
                               <td>
                                 <p
-                                  style="font-size:17px;line-height:24px;margin-top:0;margin-bottom:22px;font-weight:500">
+                                  style="font-size:17px;line-height:24px;margin-top:0;margin-bottom:24px;font-weight:500">
                                   Hello
                                   <!-- -->{{.UserName}}<!-- -->,
                                 </p>

--- a/emails/user-suspicious.tsx
+++ b/emails/user-suspicious.tsx
@@ -85,7 +85,7 @@ export const UserSuspicious = (props: UserSuspiciousProps) => {
   return (
     <MainLayout preview={previewText}>
       <Section className="my-10.5">
-        <Text className="mt-0 text-4.5 mb-5.5 leading-6 font-medium">
+        <Text className="mt-0 text-4.5 mb-6 leading-6 font-medium">
           Hello {props.UserName},
         </Text>
         <Section className="my-6">


### PR DESCRIPTION
## What this does

Restores the greeting spacing on the "suspicious sign-in" email to `mb-6` (24px), matching what was actually running in production before the infra cutover.

## Why

Diffing the 7 templates that were live in `datum` against what's now published from this repo, one had drifted: the greeting text's bottom margin was `mb-6` in production but `mb-5.5` on `main`. The infra migration ([infra#3517](https://github.com/datum-cloud/infra/pull/3517)) moved deployment from a manually-gated copy in `datum` to always-current `main` — which is the right end state, but it means this one unreviewed drift would have shipped as a silent side effect of infra work rather than a deliberate content change.

Verified: regenerating the bundle with this change produces byte-identical output to what was captured from `datum` right before it was retired (aside from an unrelated, already-known trailing-newline difference). All other 6 templates already matched exactly.

Part of #18
