### PR TITLE
Publish latest screenshots on merge

### DIFF
--- a/.github/workflows/publish-latest-screenshots.yml
+++ b/.github/workflows/publish-latest-screenshots.yml
@@ -1,0 +1,45 @@
+name: Publish Latest Screenshots
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+    paths:
+      - 'emails/**'
+
+permissions:
+  contents: write
+
+jobs:
+  screenshot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Render and screenshot every template
+        run: pnpm screenshot
+
+      - name: Publish to email-template-screenshots branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./scripts/publish-screenshots.sh latest "Latest screenshots for ${GITHUB_SHA}"

--- a/.github/workflows/screenshot-templates.yml
+++ b/.github/workflows/screenshot-templates.yml
@@ -76,29 +76,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
-          rm -rf /tmp/shots-repo
-          if git clone --depth 1 --branch email-template-screenshots "${REMOTE}" /tmp/shots-repo 2>/dev/null; then
-            :
-          else
-            mkdir -p /tmp/shots-repo
-            git -C /tmp/shots-repo init -q
-            git -C /tmp/shots-repo checkout -q --orphan email-template-screenshots
-            git -C /tmp/shots-repo commit -q --allow-empty -m "init"
-            git -C /tmp/shots-repo remote add origin "${REMOTE}"
-          fi
-
-          rm -rf "/tmp/shots-repo/pr-${PR_NUMBER}"
-          mkdir -p "/tmp/shots-repo/pr-${PR_NUMBER}"
-          cp screenshots/*.png "/tmp/shots-repo/pr-${PR_NUMBER}/"
-
-          cd /tmp/shots-repo
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "pr-${PR_NUMBER}"
-          git commit -q -m "Screenshots for PR #${PR_NUMBER} (${GITHUB_SHA})" --allow-empty
-          git push -q origin email-template-screenshots
+          ./scripts/publish-screenshots.sh "pr-${PR_NUMBER}" "Screenshots for PR #${PR_NUMBER} (${GITHUB_SHA})"
 
       - name: Build comment body
         if: steps.changed.outputs.any == 'true'

--- a/scripts/publish-screenshots.sh
+++ b/scripts/publish-screenshots.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Publishes ./screenshots/*.png to a subpath on the email-template-screenshots
+# branch. Retries on push failure since PR runs and main-merge runs can race
+# on that branch.
+#
+# Usage: GH_TOKEN=... GITHUB_REPOSITORY=owner/repo scripts/publish-screenshots.sh <dest-path> <commit-message>
+set -euo pipefail
+
+DEST_PATH="$1"
+COMMIT_MESSAGE="$2"
+
+REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+WORKDIR=$(mktemp -d)
+
+clone_or_init() {
+  rm -rf "${WORKDIR:?}"
+  if git clone --depth 1 --branch email-template-screenshots "${REMOTE}" "${WORKDIR}" 2>/dev/null; then
+    return 0
+  fi
+  mkdir -p "${WORKDIR}"
+  git -C "${WORKDIR}" init -q
+  git -C "${WORKDIR}" checkout -q --orphan email-template-screenshots
+  git -C "${WORKDIR}" commit -q --allow-empty -m "init"
+  git -C "${WORKDIR}" remote add origin "${REMOTE}"
+}
+
+for attempt in 1 2 3 4 5; do
+  clone_or_init
+
+  rm -rf "${WORKDIR:?}/${DEST_PATH}"
+  mkdir -p "${WORKDIR}/${DEST_PATH}"
+  cp screenshots/*.png "${WORKDIR}/${DEST_PATH}/"
+
+  git -C "${WORKDIR}" config user.name "github-actions[bot]"
+  git -C "${WORKDIR}" config user.email "github-actions[bot]@users.noreply.github.com"
+  git -C "${WORKDIR}" add "${DEST_PATH}"
+  git -C "${WORKDIR}" commit -q -m "${COMMIT_MESSAGE}" --allow-empty
+
+  if git -C "${WORKDIR}" push -q origin email-template-screenshots; then
+    echo "Published to ${DEST_PATH}"
+    exit 0
+  fi
+
+  echo "Push attempt ${attempt} failed (likely racing another run), retrying..."
+  sleep $((attempt * 3))
+done
+
+echo "::error::Failed to publish screenshots after multiple attempts"
+exit 1


### PR DESCRIPTION
## What this does

Adds a second screenshot workflow, `publish-latest-screenshots.yml`: regenerates screenshots for every template and publishes them to a `latest/` path whenever a PR touching `emails/**` merges to `main` — giving an always-current visual reference instead of only ephemeral per-PR ones.

Triggers on the PR closing as merged, not a `push` to `main`, since `main` is branch-protected.

Extracted the publish-to-branch logic (now shared with the per-PR workflow from #26) into `scripts/publish-screenshots.sh`, with a retry loop since both workflows push to the same `email-template-screenshots` branch and can race.

## Why this is a separate PR

This was meant to land as part of #26, but #26 merged before this commit made it in. Picking up the missed piece here.

## Sequencing

The README screenshot embed (also missed from #24, being re-opened separately) depends on this merging and running at least once before the images resolve.

Part of #18
