### PR TITLE
AI-enabled email template management for non-engineers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "email-templates",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bookworm",
+  "postCreateCommand": "sudo corepack enable && corepack prepare --activate && CI=true pnpm install",
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "Email preview server",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "biomejs.biome",
+        "bradlc.vscode-tailwindcss"
+      ],
+      "settings": {
+        "editor.defaultFormatter": "biomejs.biome",
+        "editor.formatOnSave": true
+      }
+    }
+  }
+}

--- a/.github/ISSUE_TEMPLATE/content-change-request.yml
+++ b/.github/ISSUE_TEMPLATE/content-change-request.yml
@@ -1,0 +1,52 @@
+name: Content / Wording Change Request
+description: Request a wording or content change to one of Datum's transactional emails (no coding required).
+title: "[Content]: "
+labels:
+  - content
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to request a wording or content change to one of the transactional emails in this repo. You don't need to write any code — just tell us what should change and why, and someone from the team will pick it up. For clear-cut wording swaps, a maintainer may add the `ai-draft` label to have Claude open a draft PR automatically — you'll still get a chance to review it before it merges.
+  - type: dropdown
+    id: template
+    attributes:
+      label: Which email template?
+      description: Which email does this request apply to?
+      options:
+        - Platform Invitation
+        - User Invitation
+        - User Approved
+        - User Rejected
+        - User Waitlist
+        - User Welcome
+        - Suspicious Sign-in
+        - Not sure / other
+    validations:
+      required: true
+  - type: textarea
+    id: change
+    attributes:
+      label: What should change?
+      description: Describe the current wording and what you'd like it changed to. Quote exact text where you can.
+      placeholder: |
+        Current wording: "..."
+        Desired wording: "..."
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this change needed?
+      description: Optional context or motivation — e.g. a legal requirement, a rebrand, confusing feedback from users, etc.
+    validations:
+      required: false
+  - type: input
+    id: urgency
+    attributes:
+      label: Deadline or urgency
+      description: Optional — is there a date this needs to land by, or how urgent is it?
+      placeholder: e.g. Needs to ship before the July 30 launch
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new-template-request.yml
+++ b/.github/ISSUE_TEMPLATE/new-template-request.yml
@@ -1,0 +1,77 @@
+name: New Email Template Request
+description: Request a brand-new transactional email template (no coding required).
+title: "[New template]: "
+labels:
+  - new-template
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to request a brand-new transactional email. You don't need to write any code — describe what the email should say and when it's sent, and someone from the team will pick it up. For clear-cut requests, a maintainer may add the `ai-draft` label to have Claude scaffold a first-draft PR — it'll still need engineer and brand review before it merges, since a new template involves layout and structure decisions, not just wording.
+  - type: input
+    id: name
+    attributes:
+      label: Template name
+      description: A short name for this email, e.g. "Password Reset" or "Payment Failed"
+      placeholder: e.g. Password Reset
+    validations:
+      required: true
+  - type: textarea
+    id: trigger
+    attributes:
+      label: When is this email sent?
+      description: What event or user action triggers this email?
+      placeholder: e.g. Sent when a user requests a password reset link
+    validations:
+      required: true
+  - type: dropdown
+    id: closest_existing
+    attributes:
+      label: Which existing email is this most similar to in look and feel?
+      description: Used as a structural reference — layout, tone, and components will follow this one.
+      options:
+        - Platform Invitation
+        - User Invitation
+        - User Approved
+        - User Rejected
+        - User Waitlist
+        - User Welcome
+        - Suspicious Sign-in
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: subject
+    attributes:
+      label: Subject line
+      description: Optional — if left blank, one will be derived from the heading.
+      placeholder: e.g. Reset your Datum password
+    validations:
+      required: false
+  - type: textarea
+    id: body_copy
+    attributes:
+      label: What should the email say?
+      description: Greeting, body paragraph(s), and any call-to-action button label. Plain text is fine — exact wording will be refined during review.
+      placeholder: |
+        Greeting: Hi {name},
+        Body: We received a request to reset your password. Click below to choose a new one.
+        Button label: Reset Password
+    validations:
+      required: true
+  - type: input
+    id: variables
+    attributes:
+      label: What information does this email need to fill in?
+      description: e.g. the user's name, a reset link, an expiration time — these become the template's variables.
+      placeholder: e.g. name, resetUrl, expiresInHours
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else? (legal copy, urgency, related tickets)
+      description: Optional context.
+    validations:
+      required: false

--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -1,0 +1,58 @@
+name: Draft PR for content request
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  draft-pr:
+    if: github.event.label.name == 'ai-draft' && contains(github.event.issue.labels.*.name, 'content')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          label_trigger: 'ai-draft'
+          base_branch: main
+          branch_prefix: 'content-request/'
+          claude_args: |
+            --allowedTools "Read,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*)"
+          prompt: |
+            You're handling GitHub issue #${{ github.event.issue.number }} in this repo, a
+            "Content / Wording Change Request" filed via
+            .github/ISSUE_TEMPLATE/content-change-request.yml. Read CLAUDE.md at the repo
+            root first for how this repo's template/bundle pipeline works.
+
+            The issue body has a "Which email template?" dropdown (a human-readable name
+            like "User Welcome") and a "What should change?" field describing current vs.
+            desired wording.
+
+            1. Map the dropdown's template name to its file in emails/*.tsx (e.g.
+               "User Welcome" -> emails/user-welcome.tsx, "Suspicious Sign-in" ->
+               emails/user-suspicious.tsx). If it says "Not sure / other" or you can't
+               confidently identify the file, stop and comment on the issue asking for
+               clarification instead of guessing.
+            2. Each template declares a `const copy = { ... }` object near the top holding
+               its literal strings, referenced from the JSX below it. Find the specific
+               `copy` key(s) whose current value matches the issue's described current
+               wording, and update only those values to the desired wording.
+            3. Don't touch anything else — no JSX structure, no Tailwind classNames, no
+               other templates, no other files (workflows, scripts, config).
+            4. Run `pnpm generate:all` to regenerate config/email-templates/ from your
+               change, and `pnpm check` to confirm Biome is still clean. Include the
+               regenerated config/email-templates/ output in your commit.
+            5. Open a PR against main with a clear title and a body that says
+               "Closes #${{ github.event.issue.number }}", quoting the before/after
+               wording.
+
+            If the request is ambiguous, spans multiple unrelated strings, or isn't a
+            simple wording swap (e.g. asks for new sections, new templates, or layout
+            changes), don't guess — comment on the issue explaining what you need
+            clarified instead of opening a PR.

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -1,0 +1,69 @@
+name: Draft PR for new template request
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  draft-pr:
+    if: github.event.label.name == 'ai-draft' && contains(github.event.issue.labels.*.name, 'new-template')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          label_trigger: 'ai-draft'
+          base_branch: main
+          branch_prefix: 'new-template/'
+          claude_args: |
+            --allowedTools "Read,Write,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*)"
+          prompt: |
+            You're handling GitHub issue #${{ github.event.issue.number }} in this repo, a
+            "New Email Template Request" filed via
+            .github/ISSUE_TEMPLATE/new-template-request.yml. Read CLAUDE.md at the repo
+            root and CONTRIBUTING.md's "Creating Email Templates" section first — they
+            document the exact shape every template must follow and why (the export/YAML
+            generation pipeline depends on it).
+
+            The issue gives: a template name, what triggers the email, which existing
+            template it's most similar to, an optional subject line, the greeting/body/
+            button copy, and what variables (props) it needs.
+
+            1. Derive a kebab-case file name from the template name (e.g. "Password Reset"
+               -> emails/password-reset.tsx). Confirm no file with that name already exists.
+            2. Open the existing template the issue named as closest in look and feel, and
+               follow its exact structure: the same imports (`import
+               'web-streams-polyfill/polyfill';` first, then from 'react-email', shared
+               components from './components', `MainLayout` from './layouts'), a
+               `const copy = { ... }` object near the top holding every literal string
+               (referenced from JSX below it, per the pattern already used across
+               emails/*.tsx), a typed props interface, and `.PreviewProps` with realistic
+               values for every prop.
+            3. If the issue gives a subject line, set it as `.Subject` — as a literal
+               string assigned directly (e.g. `MyEmail.Subject = "...";`), NOT a reference
+               to a `copy` key. CONTRIBUTING.md's "YAML Generation Details" section explains
+               why: the generator extracts `.Subject` via a regex expecting a literal
+               quoted string right there, and a variable reference makes it silently fall
+               back to a generic subject.
+            4. Only add this one new file. Do not modify emails/components/, emails/layouts/,
+               emails/config/, any existing template, or any file outside emails/.
+            5. Run `pnpm generate:all` to regenerate config/email-templates/ and confirm it
+               picks up the new template, and `pnpm check` to confirm Biome is clean. Include
+               the regenerated config/email-templates/ output in your commit.
+            6. Open a PR against main with a clear title and a body that says
+               "Closes #${{ github.event.issue.number }}", summarizes what you scaffolded,
+               and explicitly flags that this is a first draft — exact copy, brand colors,
+               and any legal/compliance boilerplate still need human review before merge.
+
+            This is a more open-ended task than a wording tweak: you're making layout and
+            structure choices, not just swapping a string. If the request is too vague to
+            draft confidently (unclear trigger, no reference template, missing key copy),
+            don't guess — comment on the issue asking for what's missing instead of opening
+            a PR.

--- a/.github/workflows/verify-bundle.yml
+++ b/.github/workflows/verify-bundle.yml
@@ -12,9 +12,14 @@ on:
 jobs:
   verify-bundle-up-to-date:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Checkout
+      - name: Checkout PR branch
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -30,12 +35,13 @@ jobs:
       - name: Regenerate bundle
         run: pnpm generate:all
 
-      - name: Fail if config/email-templates is out of date
-        uses: tj-actions/verify-changed-files@v20
+      - name: Commit regenerated bundle to the PR branch
+        uses: stefanzweifel/git-auto-commit-action@v7.2.0
         with:
-          path: config/email-templates
-          fail-if-changed: true
-          fail-message: "config/email-templates is out of date. Run 'pnpm generate:all' and commit the result."
+          commit_message: "chore: regenerate email template bundle"
+          file_pattern: 'config/email-templates/**'
+          commit_user_name: github-actions[bot]
+          commit_user_email: github-actions[bot]@users.noreply.github.com
 
   validate-kustomize:
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+A React Email + Tailwind CSS system for Datum's transactional emails (waitlist confirmations, invitations, sign-in alerts, etc.). The `.tsx` templates in `emails/` are the source of truth; everything else is a pipeline that turns them into the `EmailTemplate` CRD YAML consumed by production (`config/email-templates/`).
+
+## Commands
+
+```bash
+pnpm install          # setup
+pnpm dev              # live-reload preview server at localhost:3000
+
+pnpm generate:all     # export:custom + generate:yaml — the one to run before committing template changes
+pnpm export:custom    # render emails/*.tsx with placeholder tokens -> out-html/, out-text/
+pnpm generate:yaml    # turn out-html/out-text into config/email-templates/*.yaml (requires export:custom first)
+
+pnpm lint / lint:fix / format / format:fix / check / check:fix   # Biome, scoped to ./emails
+
+pnpm screenshot       # render-preview-html + screenshot-templates — literal-prop PNGs into screenshots/
+```
+
+`pnpm build` is currently broken on a clean install (ReadableStream polyfill conflict under Next.js 16/Turbopack prerendering `/preview/user-rejected`). Not used by CI or the publish pipeline — don't rely on it.
+
+There is no test suite; CI's correctness check is the bundle-verification step below.
+
+## Architecture
+
+**The generation pipeline is the core thing to understand**, since it's the reason templates can't just be edited and committed:
+
+1. `scripts/export-emails.ts` imports each top-level `emails/*.tsx`, renders it with its `PreviewProps`, but replaces every prop value with a deterministic placeholder token (`__placeholder_action_url__`) before rendering. This produces `out-html/*.html` and `out-text/*.txt` with the token embedded in place of real content.
+2. `scripts/generate-yaml.js` re-parses the source `.tsx` for the literal `PreviewProps` object, uses it to find-and-replace the placeholder tokens back into Go template syntax (`{{.actionUrl}}`), derives a subject line (explicit `.Subject` static, else first `<h1>`/`<h2>` text), and writes an `EmailTemplate` CRD YAML per template plus a `kustomization.yaml` into `config/email-templates/`.
+
+The two-step, placeholder-then-replace design exists so arbitrary prop content (URLs, names, HTML) can be safely swapped for `{{.field}}` without a templating engine understanding JSX — whatever the placeholder touches in the rendered output becomes a variable.
+
+`scripts/render-preview-html.ts` and `scripts/screenshot-templates.js` are a **separate, parallel path** used only for screenshots: they render with literal `PreviewProps` (not placeholders, since a real name screenshots better than a token) into `out-html-preview/`, then Playwright screenshots each into `screenshots/*.png`. Don't confuse this path's output with `out-html/` — they're for humans looking at diffs, not for the CRD bundle.
+
+**Screenshots are committed source, not CI artifacts**: `screenshots/*.png` is tracked in git (not gitignored) and embedded directly in `README.md` via collapsible `<details>` blocks per template, so `main`'s README always shows what's actually deployed. `.github/workflows/screenshot-templates.yml` keeps them current: on any PR touching `emails/**`, it renders the PR head and the merge-base, diffs which templates changed, screenshots only those, and commits the updated PNGs **straight onto the PR branch** (via `git-auto-commit-action`) — not to a side branch or a bot comment. This means a PR that changes a template will grow an extra "update template screenshots" commit pushed by `github-actions[bot]`; pull before pushing again, and expect `screenshots/*.png` diffs to show up in your own PR's "Files changed" tab, not a separate mechanism. Run the same rendering locally with `pnpm screenshot`.
+
+**CI enforces the pipeline stays in sync with source**: `.github/workflows/verify-bundle.yml` reruns `pnpm generate:all` on every PR touching `emails/**` or `scripts/**` and fails if `config/email-templates/` changes — meaning `config/email-templates/**` must never be hand-edited, and any template change requires running `pnpm generate:all` and committing the regenerated output alongside it.
+
+**Template structure**: each email in `emails/*.tsx` composes `MainLayout` (from `emails/layouts/`) with shared components from `emails/components/` (`CustomButton`, `EmailSupport`, `EmailSignoff`). Styling goes through the centralized Tailwind config in `emails/config/tailwind.config.ts` (brand color palette, spacing/font scale) rather than ad hoc classes, and brand constants (name, URLs, support email) live in `emails/config/brand.config.ts`. New templates need `import 'web-streams-polyfill/polyfill';` at the top and must export a default component plus `.PreviewProps` (used by both the export pipeline and dev preview) — see the template skeleton in `CONTRIBUTING.md`.
+
+**Versioning**: `.github/workflows/release.yml` is a manual `workflow_dispatch` that tags `vMAJOR.MINOR.PATCH` off `main` based on a selected patch/minor/major bump — there's no automatic semver inference from commits.
+
+**RELEASING.md**: README and CONTRIBUTING.md both link to `RELEASING.md` for the release process, but it doesn't exist on `main` yet — it currently lives only on the unmerged `docs/releasing` branch. Don't treat its absence as a broken link to fix; it's pending merge.
+
+**Ownership**: `.github/CODEOWNERS` routes all paths to `@datum-cloud/gtm` — that team is the default reviewer for any PR in this repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,19 @@
 
 A React Email + Tailwind CSS system for building Datum's transactional emails. See the [README](./README.md) for what emails live here; this page covers how to work on them.
 
+If you just need wording or content changed on an existing email and aren't comfortable opening a PR, open a "Content / Wording Change Request" issue instead (Issues → New issue). Need a brand-new email entirely? Use the "New Email Template Request" issue form instead — same idea, no coding required.
+
+For either kind of request, a maintainer may add the `ai-draft` label to have Claude open a draft PR automatically (see `.github/workflows/claude-content-request.yml` and `.github/workflows/claude-new-template.yml`). It's still a draft: someone reviews and merges it like any other PR.
+
 ## Installation
 
 ```bash
 pnpm install
 ```
+
+### Zero-setup: GitHub Codespaces
+
+If you don't want to install Node or pnpm locally, click "Code" → "Codespaces" → "Create codespace on main" on GitHub. This opens a browser-based VS Code with dependencies already installed and the dev server ready to run — just run `pnpm dev` once it loads. The same devcontainer config also works with VS Code's "Reopen in Container" if you have Docker locally but don't want to install Node/pnpm directly.
 
 ## Development
 
@@ -17,6 +25,8 @@ pnpm dev
 ```
 
 The development server will be available at [http://localhost:3000](http://localhost:3000).
+
+> **Note:** The very first template you open in a freshly started `pnpm dev` session may show a `ReadableStream.prototype.pipeTo` error page (the same underlying Next.js/Turbopack polyfill conflict noted below for `pnpm build`). Just refresh the page — it only happens once per `pnpm dev` session, on whichever route is compiled first, and works normally afterward.
 
 ## Build and Export
 
@@ -151,8 +161,20 @@ pnpm check:fix        # Automatically fix all quality issues
 
 ## Submitting changes
 
-Open a PR against `main`. CI regenerates the deployable bundle and fails if it doesn't match what you committed (see `.github/workflows/verify-bundle.yml`) — run `pnpm generate:all` before committing if you changed a template.
+Open a PR against `main`. CI regenerates the deployable bundle and, if anything changed, commits it straight onto your PR branch automatically (see `.github/workflows/verify-bundle.yml`) — pull before pushing again. You don't have to run `pnpm generate:all` locally before committing a template change, though you still can, e.g. to preview the diff.
 
 If your change affects what a template renders, CI also commits updated screenshots straight onto your PR branch (see `.github/workflows/screenshot-templates.yml`) — pull before pushing again, and check the "Files changed" tab for a visual diff. Run it locally with `pnpm screenshot`.
+
+### If a CI check goes red
+
+Most PR checks here are self-healing — CI regenerates files and pushes the result to your branch rather than just failing. Here's what each one actually does and what, if anything, you need to do:
+
+| Check | What it does | Red usually means | What to do |
+|---|---|---|---|
+| `verify-bundle-up-to-date` | Regenerates `config/email-templates/` from your template changes and auto-commits the result to your PR branch | The auto-commit itself hasn't landed yet, or `pnpm generate:all` genuinely errored (e.g. broken template code) | Pull the latest commit on your branch and re-check. Still red after pulling? Open the log — it'll show the real error from the generation step. |
+| `validate-kustomize` | Structurally validates the generated kustomize/CRD output | The generated YAML itself is malformed | Open the log; it names the specific file/field that's invalid. This points at a real bug, not staleness. |
+| `screenshot` (Screenshot Changed Templates) | Renders your changed templates and commits updated PNGs to your PR branch | Rendering the template itself failed | Open the log for the render error. If it succeeded, there's nothing to do — pull the auto-commit and check the "Files changed" tab for the visual diff. |
+
+Nothing in CI currently runs Biome (`pnpm check`) — lint/format issues won't show up as a PR check today. Run `pnpm check` locally if you want to catch them before you push; if you do see a Biome error locally, it names the offending file and line directly.
 
 See [RELEASING.md](./RELEASING.md) for how a merged change reaches production.

--- a/emails/platform-invitation.tsx
+++ b/emails/platform-invitation.tsx
@@ -4,6 +4,22 @@ import { Row, Section, Text } from 'react-email';
 import { CustomButton } from './components';
 import { MainLayout } from './layouts';
 
+const copy = {
+  preview:
+    "Join Datum's private beta - exclusive access to our open network cloud",
+  greetingPrefix: 'Hi ',
+  greetingSuffix: ',',
+  paragraph1:
+    "We're building an open network cloud to help the next generation of builders get access to some of the building blocks of the internet. I'm hoping you'll take some time to kick the tires during our private beta.",
+  paragraph2:
+    "We're intentionally keeping this group small so we can listen closely to feedback.",
+  buttonLabel: 'Get started',
+  paragraph3: 'Let me know your thoughts?',
+  signoffClosing: 'Cheers,',
+  signoffName: 'Zac Smith',
+  signoffTitle: 'Co-founder & CEO at Datum',
+};
+
 interface PlatformInvitationProps {
   UserName: string;
   ActionUrl: string;
@@ -13,44 +29,42 @@ export const PlatformInvitation = ({
   UserName,
   ActionUrl,
 }: PlatformInvitationProps) => {
-  const previewText = `Join Datum's private beta - exclusive access to our open network cloud`;
+  const previewText = copy.preview;
 
   return (
     <MainLayout preview={previewText}>
       <Section className="my-10.5">
         <Row>
           <Text className="mt-0 text-4.5 mb-5.5 leading-6 font-medium">
-            Hi {UserName},
+            {copy.greetingPrefix}
+            {UserName}
+            {copy.greetingSuffix}
           </Text>
           <Text className="mt-0 mb-5.5 text-4.5 leading-6 font-normal">
-            We&apos;re building an open network cloud to help the next
-            generation of builders get access to some of the building blocks of
-            the internet. I&apos;m hoping you&apos;ll take some time to kick the
-            tires during our private beta.
+            {copy.paragraph1}
           </Text>
           <Text className="text-4.5 leading-6 m-0 font-normal">
-            We&apos;re intentionally keeping this group small so we can listen
-            closely to feedback.
+            {copy.paragraph2}
           </Text>
           {ActionUrl && (
             <CustomButton
               href={ActionUrl || ''}
               className="mt-9 mb-8 block text-[16px] font-semibold leading-5"
             >
-              Get started
+              {copy.buttonLabel}
             </CustomButton>
           )}
           <Text className="text-4.5 leading-6 m-0 font-normal">
-            Let me know your thoughts?
+            {copy.paragraph3}
           </Text>
 
           <Text className="text-4.5 leading-6 font-normal mt-5.5 mb-0">
-            Cheers,
+            {copy.signoffClosing}
             <br />
             <br />
-            Zac Smith
+            {copy.signoffName}
             <br />
-            Co-founder & CEO at Datum
+            {copy.signoffTitle}
           </Text>
         </Row>
       </Section>

--- a/emails/user-approved.tsx
+++ b/emails/user-approved.tsx
@@ -5,54 +5,70 @@ import { CustomButton } from './components';
 import { brandConfig } from './config/brand.config';
 import { MainLayout } from './layouts';
 
+const copy = {
+  preview: 'Your account has been approved',
+  greetingPrefix: 'Hi ',
+  greetingSuffix: ',',
+  paragraph1:
+    "Good news, you're off the waitlist! I'm excited to share what we've built (so far) with Datum Cloud and get your feedback. To get started, just login below:",
+  buttonLabel: 'Start building',
+  paragraph2Before:
+    "We're releasing new features each week and chatting about issues and opportunities on",
+  discordLabel: 'Discord',
+  paragraph2After:
+    '. Feel free to join me there with any questions or feedback.',
+  signoffClosing: 'Cheers,',
+  signoffName: 'Zac Smith',
+  signoffTitle: 'Co-founder & CEO at Datum',
+};
+
 interface UserApprovedProps {
   UserName: string;
   ActionUrl: string;
 }
 
 export const UserApproved = ({ UserName, ActionUrl }: UserApprovedProps) => {
-  const previewText = `Your account has been approved`;
+  const previewText = copy.preview;
 
   return (
     <MainLayout preview={previewText}>
       <Section className="my-10.5">
         <Row>
           <Text className="mt-0 text-4.5 mb-5.5 leading-6 font-medium">
-            Hi {UserName},
+            {copy.greetingPrefix}
+            {UserName}
+            {copy.greetingSuffix}
           </Text>
           <Text className="mt-0 mb-5.5 text-4.5 leading-6 font-normal">
-            Good news, you&apos;re off the waitlist! I&apos;m excited to share
-            what we&apos;ve built (so far) with Datum Cloud and get your
-            feedback. To get started, just login below:
+            {copy.paragraph1}
           </Text>
           {ActionUrl && (
             <CustomButton
               href={ActionUrl || ''}
               className="mt-9 mb-8 block text-[16px] font-semibold leading-5"
             >
-              Start building
+              {copy.buttonLabel}
             </CustomButton>
           )}
           <Text className="text-4.5 leading-6 font-normal">
-            We&apos;re releasing new features each week and chatting about
-            issues and opportunities on{' '}
+            {copy.paragraph2Before}{' '}
             <Link
               href={brandConfig.discordUrl}
               target="_blank"
               className="!text-brand-canyon-clay !underline"
             >
-              Discord
+              {copy.discordLabel}
             </Link>
-            . Feel free to join me there with any questions or feedback.
+            {copy.paragraph2After}
           </Text>
 
           <Text className="text-4.5 leading-6 font-normal mt-5.5 mb-0">
-            Cheers,
+            {copy.signoffClosing}
             <br />
             <br />
-            Zac Smith
+            {copy.signoffName}
             <br />
-            Co-founder & CEO at Datum
+            {copy.signoffTitle}
           </Text>
         </Row>
       </Section>

--- a/emails/user-invitation.tsx
+++ b/emails/user-invitation.tsx
@@ -5,6 +5,24 @@ import { CustomButton } from './components';
 import { brandConfig } from './config/brand.config';
 import { MainLayout } from './layouts';
 
+const copy = {
+  preview: (inviterDisplayName: string, organizationDisplayName: string) =>
+    `${inviterDisplayName} invited you to join ${organizationDisplayName}`,
+  heading: 'Hey there!',
+  introBefore: ' has invited you to join the',
+  introAfter: ' organization at Datum.',
+  paragraph1Before:
+    'Please click the button to set up your account and get started. If you need help, just reply to this email or visit us on',
+  discordLabel: 'Discord',
+  paragraph1After: '.',
+  buttonLabel: 'Accept invitation',
+  paragraph2Before:
+    'Or you can copy and paste the following URL into your browser:',
+  whyHeading: 'Why Datum?',
+  whyParagraph:
+    'Datum is a venture-backed startup based in New York City. Our mission is to help 1k new clouds thrive in the age of AI by unlocking internet superpowers for every builder.',
+};
+
 interface UserInvitationProps {
   InviterDisplayName: string;
   OrganizationDisplayName: string;
@@ -16,43 +34,44 @@ export const UserInvitation = ({
   OrganizationDisplayName,
   UserInvitationName,
 }: UserInvitationProps) => {
-  const previewText = `${InviterDisplayName} invited you to join ${OrganizationDisplayName}`;
+  const previewText = copy.preview(InviterDisplayName, OrganizationDisplayName);
+  const invitationUrl = `https://cloud.datum.net/invitation/${UserInvitationName}/accept`;
 
   return (
     <MainLayout preview={previewText}>
       <Section className="my-10.5">
         <Row>
           <Text className="mt-0 text-2xl mb-5.5 leading-10 font-medium">
-            Hey there!
+            {copy.heading}
           </Text>
           <Text className="mt-0 mb-5.5 text-4.5 leading-6 font-normal">
-            {InviterDisplayName} has invited you to join the{' '}
-            {OrganizationDisplayName} organization at Datum.
+            {InviterDisplayName}
+            {copy.introBefore} {OrganizationDisplayName}
+            {copy.introAfter}
           </Text>
           <Text className="m-0 text-4.5 leading-6 font-normal">
-            Please click the button to set up your account and get started. If
-            you need help, just reply to this email or visit us on{' '}
+            {copy.paragraph1Before}{' '}
             <Link
               href={brandConfig.discordUrl}
               target="_blank"
               className="text-brand-canyon-clay underline"
             >
-              Discord
+              {copy.discordLabel}
             </Link>
-            .
+            {copy.paragraph1After}
           </Text>
           {UserInvitationName && (
             <CustomButton
-              href={`https://cloud.datum.net/invitation/${UserInvitationName}/accept`}
+              href={invitationUrl}
               className="mt-9 mb-8 block text-[16px] font-semibold leading-5"
             >
-              Accept invitation
+              {copy.buttonLabel}
             </CustomButton>
           )}
           <Text className="text-sm leading-5 font-normal">
-            Or you can copy and paste the following URL into your browser:{' '}
+            {copy.paragraph2Before}{' '}
             <Link
-              href={`https://cloud.datum.net/invitation/${UserInvitationName}/accept`}
+              href={invitationUrl}
               className="text-brand-canyon-clay underline"
             >
               https://cloud.datum.net/invitation/{UserInvitationName}/accept
@@ -63,12 +82,10 @@ export const UserInvitation = ({
         <Row>
           <Hr className="mx-0 my-10.5 block border border-brand-light-gray border-solid" />
           <Text className="mt-0 text-[21px] leading-7 font-semibold mb-[11px]">
-            Why Datum?
+            {copy.whyHeading}
           </Text>
           <Text className="m-0 text-4.5 leading-6 font-normal">
-            Datum is a venture-backed startup based in New York City. Our
-            mission is to help 1k new clouds thrive in the age of AI by
-            unlocking internet superpowers for every builder.
+            {copy.whyParagraph}
           </Text>
         </Row>
       </Section>

--- a/emails/user-rejected.tsx
+++ b/emails/user-rejected.tsx
@@ -3,33 +3,45 @@ import 'web-streams-polyfill/polyfill';
 import { Row, Section, Text } from 'react-email';
 import { MainLayout } from './layouts';
 
+const copy = {
+  preview: 'Your account has been rejected',
+  greetingPrefix: 'Hi ',
+  greetingSuffix: ',',
+  paragraph1:
+    "Thank you for your interest in Datum Cloud. Unfortunately, we're unable to approve your account at this time.",
+  paragraph2:
+    'If you have questions, or think this decision is in error, please respond to this email and we can investigate further.',
+  signoffClosing: 'Many thanks,',
+  signoffName: 'The Team at Datum',
+};
+
 interface UserRejectedProps {
   UserName: string;
 }
 
 export const UserRejected = ({ UserName }: UserRejectedProps) => {
-  const previewText = `Your account has been rejected`;
+  const previewText = copy.preview;
 
   return (
     <MainLayout preview={previewText}>
       <Section className="my-10.5">
         <Row>
           <Text className="mt-0 text-4.5 mb-5.5 leading-6 font-medium">
-            Hi {UserName},
+            {copy.greetingPrefix}
+            {UserName}
+            {copy.greetingSuffix}
           </Text>
           <Text className="mt-0 mb-5.5 text-4.5 leading-6 font-normal">
-            Thank you for your interest in Datum Cloud. Unfortunately,
-            we&apos;re unable to approve your account at this time.
+            {copy.paragraph1}
           </Text>
           <Text className="text-4.5 leading-6 m-0 font-normal">
-            If you have questions, or think this decision is in error, please
-            respond to this email and we can investigate further.
+            {copy.paragraph2}
           </Text>
           <Text className="text-4.5 leading-6 font-normal mt-5.5 mb-0">
-            Many thanks,
+            {copy.signoffClosing}
             <br />
             <br />
-            The Team at Datum
+            {copy.signoffName}
           </Text>
         </Row>
       </Section>

--- a/emails/user-suspicious.tsx
+++ b/emails/user-suspicious.tsx
@@ -3,6 +3,26 @@ import 'web-streams-polyfill/polyfill';
 import { Hr, Link, Row, Section, Text } from 'react-email';
 import { MainLayout } from './layouts';
 
+const copy = {
+  preview: 'New sign-in detected on your Datum account',
+  greetingPrefix: 'Hello ',
+  greetingSuffix: ',',
+  accountIntroBefore: 'Your Datum account',
+  accountIntroAfter:
+    'was recently signed-in from a new location, device or browser:',
+  recognizeActivity:
+    "If you recognize this activity, you don't need to do anything.",
+  notYouBefore: "If this wasn't you,",
+  reviewAccountLabel: 'review your account',
+  notYouAfter: 'and change your authentication methods now.',
+  alertExplanation:
+    'This alert triggers when we detect a sign-in from an unrecognized location, device, or browser. Common causes: traveling, VPN or Private Relay, or a new browser.',
+  supportHeading: 'We’re here to help',
+  supportParagraph:
+    'Please do not reply to this message. If you need help, send us a note at',
+  supportEmail: 'support@datum.net',
+};
+
 /**
  * Props for the suspicious sign-in notification.
  *
@@ -77,25 +97,27 @@ const detailRows = (
 ];
 
 export const UserSuspicious = (props: UserSuspiciousProps) => {
-  const previewText = 'New sign-in detected on your Datum account';
+  const previewText = copy.preview;
   const detailRowsData = detailRows(props);
 
   return (
     <MainLayout preview={previewText}>
       <Section className="my-10.5">
         <Text className="mt-0 text-4.5 mb-6 leading-6 font-medium">
-          Hello {props.UserName},
+          {copy.greetingPrefix}
+          {props.UserName}
+          {copy.greetingSuffix}
         </Text>
         <Section className="my-6">
           <Text className="mt-0 text-4.5 mb-6 leading-6 font-normal">
-            Your Datum account{' '}
+            {copy.accountIntroBefore}{' '}
             <Link
               href={`mailto:${props.Email}`}
               className="font-semibold text-brand-navy"
             >
               {props.Email}
             </Link>{' '}
-            was recently signed-in from a new location, device or browser:
+            {copy.accountIntroAfter}
           </Text>
 
           {detailRowsData.map((row) => (
@@ -105,42 +127,39 @@ export const UserSuspicious = (props: UserSuspiciousProps) => {
           ))}
 
           <Text className="mt-6 mb-6 text-4.5 leading-6 font-normal">
-            If you recognize this activity, you don't need to do anything.
+            {copy.recognizeActivity}
           </Text>
 
           <Text className="mt-0 text-4.5 leading-6 font-normal">
-            If this wasn't you,{' '}
+            {copy.notYouBefore}{' '}
             <Link
               href="https://cloud.datum.net/"
               className="text-brand-canyon-clay underline"
             >
-              review your account
+              {copy.reviewAccountLabel}
             </Link>{' '}
-            and change your authentication methods now.
+            {copy.notYouAfter}
           </Text>
         </Section>
 
         <Text className="text-[14px] leading-5 font-normal m-0">
-          This alert triggers when we detect a sign-in from an unrecognized
-          location, device, or browser. Common causes: traveling, VPN or Private
-          Relay, or a new browser.
+          {copy.alertExplanation}
         </Text>
 
         <Row>
           <Hr className="mx-0 my-10.5 block border border-brand-light-gray border-solid" />
           <Text className="m-0 text-[21px] leading-7 font-semibold">
-            We’re here to help
+            {copy.supportHeading}
           </Text>
           <Text className="m-0 my-[12px] text-4.5 leading-6 font-normal">
-            Please do not reply to this message. If you need help, send us a
-            note at
+            {copy.supportParagraph}
           </Text>
 
           <Link
             href="mailto:support@datum.net"
             className="text-brand-canyon-clay underline m-0 text-4.5 font-semibold"
           >
-            support@datum.net
+            {copy.supportEmail}
           </Link>
         </Row>
       </Section>

--- a/emails/user-waitlist.tsx
+++ b/emails/user-waitlist.tsx
@@ -3,37 +3,49 @@ import 'web-streams-polyfill/polyfill';
 import { Row, Section, Text } from 'react-email';
 import { MainLayout } from './layouts';
 
+const copy = {
+  preview: "You're on the waitlist",
+  greetingPrefix: 'Hi ',
+  greetingSuffix: ',',
+  paragraph1:
+    "Thanks for joining the waitlist for Datum Cloud. We're currently in a private beta, but we're onboarding people in batches every week.",
+  paragraph2:
+    "I'd love to hear about your use case, or what you feel is missing in your toolkit. Just reply to this email with any thoughts.",
+  signoffClosing: 'Cheers,',
+  signoffName: 'Zac Smith',
+  signoffTitle: 'Co-founder & CEO at Datum',
+};
+
 interface UserWaitlistProps {
   UserName: string;
 }
 
 export const UserWaitlist = ({ UserName }: UserWaitlistProps) => {
-  const previewText = `You're on the waitlist`;
+  const previewText = copy.preview;
 
   return (
     <MainLayout preview={previewText}>
       <Section className="my-10.5">
         <Row>
           <Text className="mt-0 text-4.5 mb-5.5 leading-6 font-medium">
-            Hi {UserName},
+            {copy.greetingPrefix}
+            {UserName}
+            {copy.greetingSuffix}
           </Text>
           <Text className="mt-0 mb-5.5 text-4.5 leading-6 font-normal">
-            Thanks for joining the waitlist for Datum Cloud. We&apos;re
-            currently in a private beta, but we're onboarding people in batches
-            every week.
+            {copy.paragraph1}
           </Text>
           <Text className="text-4.5 leading-6 m-0 font-normal">
-            I&apos;d love to hear about your use case, or what you feel is
-            missing in your toolkit. Just reply to this email with any thoughts.
+            {copy.paragraph2}
           </Text>
 
           <Text className="text-4.5 leading-6 font-normal mt-5.5 mb-0">
-            Cheers,
+            {copy.signoffClosing}
             <br />
             <br />
-            Zac Smith
+            {copy.signoffName}
             <br />
-            Co-founder & CEO at Datum
+            {copy.signoffTitle}
           </Text>
         </Row>
       </Section>

--- a/emails/user-welcome.tsx
+++ b/emails/user-welcome.tsx
@@ -4,33 +4,54 @@ import { Link, Row, Section, Text } from 'react-email';
 import { brandConfig } from './config/brand.config';
 import { MainLayout } from './layouts';
 
+const copy = {
+  preview: (userName: string) => `${userName} Welcome to Datum!`,
+  greetingPrefix: 'Hey ',
+  greetingSuffix: ", welcome to Datum! We're glad you're here.",
+  paragraph1:
+    "Datum is building for a future that is evolving in front of our eyes, so we're shipping updates all the time. We're also serious about making improvements based on feedback, so if you've got some for us (good, bad, ugly) we'd love to have it.",
+  paragraph2: "Here's how to stay in the loop, get help, or get involved:",
+  emailLabel: 'Email',
+  emailDescription: " – Respond to this note and we'll get back to you",
+  discordLabel: 'Discord',
+  discordDescription: '– Join for support and connect with other builders',
+  lumaLabel: 'Luma',
+  lumaDescription: '– Know when and where to meet us in person',
+  githubDiscussionsLabel: 'GitHub Discussions',
+  githubDiscussionsDescription:
+    '– Submit feedback, report issues, or request & upvote features',
+  careersLabel: 'Careers',
+  careersDescription:
+    "– We're actively hiring, and value folks spreading the word",
+  signoffEmoji: '❤️',
+  signoffName: 'The Team at Datum',
+};
+
 interface UserWelcomeProps {
   UserName: string;
 }
 
 export const UserWelcome = ({ UserName }: UserWelcomeProps) => {
-  const previewText = `${UserName} Welcome to Datum!`;
+  const previewText = copy.preview(UserName);
 
   return (
     <MainLayout preview={previewText}>
       <Section className="my-10.5">
         <Row>
           <Text className="mt-0 text-4.5 mb-5.5 leading-6 font-medium">
-            Hey {UserName}, welcome to Datum! We&apos;re glad you&apos;re here.
+            {copy.greetingPrefix}
+            {UserName}
+            {copy.greetingSuffix}
           </Text>
           <Text className="mt-0 mb-5.5 text-4.5 leading-6 font-normal">
-            Datum is building for a future that is evolving in front of our
-            eyes, so we&apos;re shipping updates all the time. We&apos;re also
-            serious about making improvements based on feedback, so if
-            you&apos;ve got some for us (good, bad, ugly) we&apos;d love to have
-            it.
+            {copy.paragraph1}
           </Text>
           <Text className="mt-0 mb-5.5 text-4.5 leading-6 font-normal">
-            Here&apos;s how to stay in the loop, get help, or get involved:
+            {copy.paragraph2}
           </Text>
           <Text className="mt-0 mb-2 text-4.5 leading-6 font-normal">
-            <span className="font-semibold">Email</span> – Respond to this note
-            and we&apos;ll get back to you
+            <span className="font-semibold">{copy.emailLabel}</span>
+            {copy.emailDescription}
           </Text>
           <Text className="mt-0 mb-2 text-4.5 leading-6 font-normal">
             <Link
@@ -38,9 +59,9 @@ export const UserWelcome = ({ UserName }: UserWelcomeProps) => {
               target="_blank"
               className="text-brand-canyon-clay underline font-semibold"
             >
-              Discord
+              {copy.discordLabel}
             </Link>{' '}
-            – Join for support and connect with other builders
+            {copy.discordDescription}
           </Text>
           <Text className="mt-0 mb-2 text-4.5 leading-6 font-normal">
             <Link
@@ -48,9 +69,9 @@ export const UserWelcome = ({ UserName }: UserWelcomeProps) => {
               target="_blank"
               className="text-brand-canyon-clay underline font-semibold"
             >
-              Luma
+              {copy.lumaLabel}
             </Link>{' '}
-            – Know when and where to meet us in person
+            {copy.lumaDescription}
           </Text>
           <Text className="mt-0 mb-2 text-4.5 leading-6 font-normal">
             <Link
@@ -58,9 +79,9 @@ export const UserWelcome = ({ UserName }: UserWelcomeProps) => {
               target="_blank"
               className="text-brand-canyon-clay underline font-semibold"
             >
-              GitHub Discussions
+              {copy.githubDiscussionsLabel}
             </Link>{' '}
-            – Submit feedback, report issues, or request &amp; upvote features
+            {copy.githubDiscussionsDescription}
           </Text>
           <Text className="mt-0 mb-0 text-4.5 leading-6 font-normal">
             <Link
@@ -68,15 +89,15 @@ export const UserWelcome = ({ UserName }: UserWelcomeProps) => {
               target="_blank"
               className="text-brand-canyon-clay underline font-semibold"
             >
-              Careers
+              {copy.careersLabel}
             </Link>{' '}
-            – We&apos;re actively hiring, and value folks spreading the word
+            {copy.careersDescription}
           </Text>
 
           <Text className="text-4.5 leading-6 font-normal mt-5.5 mb-0">
-            {'\u2764\uFE0F'}
+            {copy.signoffEmoji}
             <br />
-            The Team at Datum
+            {copy.signoffName}
           </Text>
         </Row>
       </Section>


### PR DESCRIPTION
## Summary

A batch of changes aimed at lowering the bar for non-technical stakeholders and junior developers to contribute to email templates:

- **`CLAUDE.md`** — architecture/pipeline guidance for AI coding assistants working in this repo
- **CI auto-commit** — `verify-bundle.yml` now regenerates and commits the bundle to the PR branch instead of failing, matching the existing screenshot-workflow pattern
- **Devcontainer** — zero-setup GitHub Codespaces / "Reopen in Container" path; verified end-to-end against the real devcontainer CLI, two real bugs found and fixed along the way (see commit for details)
- **Copy extraction** — each template's text now lives in a `const copy` object separate from JSX/Tailwind markup, so a wording diff reads as a wording diff. Verified byte-identical rendered output (bundle + screenshots) before/after
- **Issue-driven requests** — two issue forms ("Content / Wording Change Request" and "New Email Template Request") so non-engineers can ask for changes without opening a PR
- **AI-assisted draft PRs** — a maintainer-gated `ai-draft` label triggers a `claude-code-action` workflow that drafts the actual PR from the issue (content swap or new-template scaffold), still subject to normal CODEOWNERS review and the screenshot preview
- **CONTRIBUTING.md** — documents all of the above, plus a plain-language "if CI goes red" table and a caveat about a transient (pre-existing, unrelated to this PR) `pnpm dev` first-load error

## Before this can go live

- Add an `ANTHROPIC_API_KEY` repo secret (or set up a Claude Code OAuth token) — neither `claude-*.yml` workflow can run without it
- The `content`, `new-template`, `needs-triage`, and `ai-draft` labels have already been created on this repo

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm generate:all` produces a byte-identical `config/email-templates/` bundle before/after the copy-extraction refactor
- [x] `pnpm screenshot` produces byte-identical PNGs to what's committed on `main`
- [x] Built and ran the devcontainer against a real Docker/Colima daemon; confirmed `pnpm dev` serves rendered templates from inside it
- [x] Live-fire test of the `claude-*.yml` workflows — superseded the `ANTHROPIC_API_KEY` plan with Workload Identity Federation instead (#32); actual live runs happened in #32–#36, which found and fixed several real bugs (tool permissions, auto-trigger security, missing issue content). End-to-end success (an actual opened PR) still tracked in #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)