### PR TITLE
Authenticate Claude workflows via Workload Identity Federation

### DIFF
--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -1,3 +1,12 @@
+# Authenticates to the Claude API via Workload Identity Federation instead of a
+# static ANTHROPIC_API_KEY secret: GitHub mints a short-lived OIDC token for this
+# job (hence `id-token: write` below), and claude-code-action exchanges it for a
+# short-lived Anthropic access token. No long-lived key is stored in this repo.
+#
+# The four ANTHROPIC_* values below are repo variables (Settings -> Secrets and
+# variables -> Actions -> Variables), not secrets — they identify resources, not
+# credentials. Setup (Console federation issuer/rule/service account) is documented at
+# https://platform.claude.com/docs/en/manage-claude/wif-providers/github-actions
 name: Draft PR for content request
 
 on:
@@ -8,6 +17,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   draft-pr:
@@ -18,7 +28,10 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          anthropic_workspace_id: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
           label_trigger: 'ai-draft'
           base_branch: main
           branch_prefix: 'content-request/'

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -1,3 +1,6 @@
+# Authenticates via Workload Identity Federation (GitHub OIDC -> short-lived
+# Anthropic token) instead of a static ANTHROPIC_API_KEY secret — see the setup
+# steps and repo variables documented at the top of claude-content-request.yml.
 name: Draft PR for new template request
 
 on:
@@ -8,6 +11,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   draft-pr:
@@ -18,7 +22,10 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          anthropic_workspace_id: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
           label_trigger: 'ai-draft'
           base_branch: main
           branch_prefix: 'new-template/'


### PR DESCRIPTION
## Summary

Follow-up to #31 — replaces the `ANTHROPIC_API_KEY` secret requirement on `claude-content-request.yml` and `claude-new-template.yml` with Workload Identity Federation: GitHub mints a short-lived OIDC token for the job, and `claude-code-action` exchanges it for a short-lived Anthropic access token natively. No long-lived key is stored in this repo.

- Both workflows now pass `anthropic_federation_rule_id` / `anthropic_organization_id` / `anthropic_service_account_id` / `anthropic_workspace_id` (sourced from repo variables, not secrets — these identify resources, not credentials) instead of `anthropic_api_key`.
- Both gain `id-token: write` permission, required for GitHub to mint the OIDC token.
- The four repo variables (`ANTHROPIC_ORGANIZATION_ID`, `ANTHROPIC_SERVICE_ACCOUNT_ID`, `ANTHROPIC_FEDERATION_RULE_ID`, `ANTHROPIC_WORKSPACE_ID`) are already set on this repo.

## Verification

The token exchange was verified end-to-end with a standalone smoke test workflow (since removed from this PR — it served its purpose confirming the Console-side federation setup) that drove the raw HTTP exchange directly: it returned a valid `access_token`, `expires_in: 598`, and `scope: workspace:developer` with no errors.

## Test plan

- [x] Confirmed the raw token exchange succeeds against the configured federation rule
- [x] Exercised the real `ai-draft` flow on test issue #33 (across several follow-up runs) — `claude-code-action` federates successfully every time (`Workload identity federation configured (rule: ...)`, Claude Code initializes and runs against the real API). Federation itself has never been the failure point; the runs surfaced separate bugs (tool permissions in #34, an auto-trigger security gap in #35, missing issue content in #36) that are being fixed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)