### PR TITLE
fix: AI draft PR workflows — tool permissions, auto-trigger, shared settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Edit",
+      "Bash(pnpm install:*)",
+      "Bash(pnpm dev:*)",
+      "Bash(pnpm generate:all:*)",
+      "Bash(pnpm generate:yaml:*)",
+      "Bash(pnpm export:custom:*)",
+      "Bash(pnpm check:*)",
+      "Bash(pnpm check:fix:*)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm format:*)",
+      "Bash(git:*)",
+      "Bash(gh pr create:*)"
+    ]
+  }
+}

--- a/.github/ISSUE_TEMPLATE/content-change-request.yml
+++ b/.github/ISSUE_TEMPLATE/content-change-request.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form to request a wording or content change to one of the transactional emails in this repo. You don't need to write any code — just tell us what should change and why, and someone from the team will pick it up. For clear-cut wording swaps, a maintainer may add the `ai-draft` label to have Claude open a draft PR automatically — you'll still get a chance to review it before it merges.
+        Use this form to request a wording or content change to one of the transactional emails in this repo. You don't need to write any code — just tell us what should change and why. Claude will automatically attempt a draft PR as soon as you submit this issue; someone from the team still reviews it before it merges. If the automated attempt doesn't work out, a maintainer can add the `ai-draft` label to retry it.
   - type: dropdown
     id: template
     attributes:

--- a/.github/ISSUE_TEMPLATE/new-template-request.yml
+++ b/.github/ISSUE_TEMPLATE/new-template-request.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form to request a brand-new transactional email. You don't need to write any code — describe what the email should say and when it's sent, and someone from the team will pick it up. For clear-cut requests, a maintainer may add the `ai-draft` label to have Claude scaffold a first-draft PR — it'll still need engineer and brand review before it merges, since a new template involves layout and structure decisions, not just wording.
+        Use this form to request a brand-new transactional email. You don't need to write any code — describe what the email should say and when it's sent. Claude will automatically attempt a first-draft PR as soon as you submit this issue — it'll still need engineer and brand review before it merges, since a new template involves layout and structure decisions, not just wording. If the automated attempt doesn't work out, a maintainer can add the `ai-draft` label to retry it.
   - type: input
     id: name
     attributes:

--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -35,8 +35,9 @@ jobs:
           label_trigger: 'ai-draft'
           base_branch: main
           branch_prefix: 'content-request/'
+          show_full_output: true
           claude_args: |
-            --allowedTools "Read,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*)"
+            --allowedTools "Read,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr create:*)"
           prompt: |
             You're handling GitHub issue #${{ github.event.issue.number }} in this repo, a
             "Content / Wording Change Request" filed via

--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -9,9 +9,13 @@
 # https://platform.claude.com/docs/en/manage-claude/wif-providers/github-actions
 name: Draft PR for content request
 
+# Fires automatically when a "Content / Wording Change Request" issue is opened
+# (the issue form applies the `content` label at creation). If that run fails
+# or gets a mediocre result, re-trigger it by adding (or re-adding) the
+# `ai-draft` label on the issue — that's the manual retry path.
 on:
   issues:
-    types: [labeled]
+    types: [opened, labeled]
 
 permissions:
   contents: write
@@ -21,7 +25,9 @@ permissions:
 
 jobs:
   draft-pr:
-    if: github.event.label.name == 'ai-draft' && contains(github.event.issue.labels.*.name, 'content')
+    if: >
+      contains(github.event.issue.labels.*.name, 'content') &&
+      (github.event.action == 'opened' || github.event.label.name == 'ai-draft')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -1,11 +1,15 @@
 # Authenticates via Workload Identity Federation (GitHub OIDC -> short-lived
 # Anthropic token) instead of a static ANTHROPIC_API_KEY secret — see the setup
 # steps and repo variables documented at the top of claude-content-request.yml.
+# Fires automatically when a "New Email Template Request" issue is opened (the
+# issue form applies the `new-template` label at creation). If that run fails
+# or gets a mediocre result, re-trigger it by adding (or re-adding) the
+# `ai-draft` label on the issue — that's the manual retry path.
 name: Draft PR for new template request
 
 on:
   issues:
-    types: [labeled]
+    types: [opened, labeled]
 
 permissions:
   contents: write
@@ -15,7 +19,9 @@ permissions:
 
 jobs:
   draft-pr:
-    if: github.event.label.name == 'ai-draft' && contains(github.event.issue.labels.*.name, 'new-template')
+    if: >
+      contains(github.event.issue.labels.*.name, 'new-template') &&
+      (github.event.action == 'opened' || github.event.label.name == 'ai-draft')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -35,8 +35,9 @@ jobs:
           label_trigger: 'ai-draft'
           base_branch: main
           branch_prefix: 'new-template/'
+          show_full_output: true
           claude_args: |
-            --allowedTools "Read,Write,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*)"
+            --allowedTools "Read,Write,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr create:*)"
           prompt: |
             You're handling GitHub issue #${{ github.event.issue.number }} in this repo, a
             "New Email Template Request" filed via

--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,6 @@ Thumbs.db
 *.tsbuildinfo
 .tsc-watch/
 
-.claude/
+.claude/*
+!.claude/settings.json
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ A React Email + Tailwind CSS system for building Datum's transactional emails. S
 
 If you just need wording or content changed on an existing email and aren't comfortable opening a PR, open a "Content / Wording Change Request" issue instead (Issues → New issue). Need a brand-new email entirely? Use the "New Email Template Request" issue form instead — same idea, no coding required.
 
-For either kind of request, a maintainer may add the `ai-draft` label to have Claude open a draft PR automatically (see `.github/workflows/claude-content-request.yml` and `.github/workflows/claude-new-template.yml`). It's still a draft: someone reviews and merges it like any other PR.
+For either kind of request, Claude automatically attempts a draft PR as soon as the issue is opened (see `.github/workflows/claude-content-request.yml` and `.github/workflows/claude-new-template.yml`) — it's still a draft: someone reviews and merges it like any other PR. If that automated attempt fails or falls short, a maintainer can add the `ai-draft` label to the issue to retry it.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Fixes found and applied while getting the `ai-draft` flow (issues #33) working end-to-end:

1. **Tool permissions bug** — `claude-content-request.yml`'s allowlist (`Read,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*)`) let Claude edit the template and regenerate the bundle, but blocked it from committing/pushing/opening the PR. Confirmed live: the test run reported `permission_denials_count: 7`, no branch or PR was created, and no error surfaced to the issue. Added `Bash(git:*)` and `Bash(gh pr create:*)`.
2. **Same bug in `claude-new-template.yml`** — it had the identical gap (would have failed the same way on first real use). Applied the same fix there.
3. **Auto-trigger instead of manual labeling** — both workflows now also fire on `issues: opened` (the issue forms already apply `content`/`new-template` at creation), so a maintainer no longer has to add `ai-draft` manually. The `ai-draft` label remains as the manual retry path if an automatic attempt fails or falls short. Issue form text and CONTRIBUTING.md updated to match.
4. **`.claude/settings.json` added** — a project-level baseline (documented pnpm scripts, `git`, `gh pr create`) so both workflows and anyone running Claude Code locally share one source of truth instead of copy-pasted `--allowedTools` lists. Deliberately excludes `Write`, so `claude-content-request.yml` still can't create new files — that stays a per-workflow addition specific to `claude-new-template.yml`.
5. `show_full_output: true` temporarily enabled on both workflows for debugging visibility — revert once confirmed working.

> Note: the auto-trigger security gap this PR introduced (any public GitHub user could trigger it) was found and fixed separately in #35. The tool-permission fix here got the run past the git/PR step, but a follow-up run then surfaced a different bug (Claude had no way to read the issue's actual content) — fixed in #36.

## Test plan

- [ ] Merge, re-add the `ai-draft` label to issue #33 (or let a fresh issue auto-trigger), confirm a PR actually opens this time — blocked until #36 merges (missing issue content bug)
- [ ] Confirm `claude-new-template.yml` also works via a fresh "New Email Template Request" test issue — not yet attempted
- [ ] Revert `show_full_output` back to false once both are confirmed — still pending, still needed for debugging