### PR TITLE
Restrict AI auto-trigger to trusted authors; consolidate tool permissions into settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
     "allow": [
       "Read",
       "Edit",
+      "Write",
       "Bash(pnpm install:*)",
       "Bash(pnpm dev:*)",
       "Bash(pnpm generate:all:*)",

--- a/.github/ISSUE_TEMPLATE/content-change-request.yml
+++ b/.github/ISSUE_TEMPLATE/content-change-request.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form to request a wording or content change to one of the transactional emails in this repo. You don't need to write any code — just tell us what should change and why. Claude will automatically attempt a draft PR as soon as you submit this issue; someone from the team still reviews it before it merges. If the automated attempt doesn't work out, a maintainer can add the `ai-draft` label to retry it.
+        Use this form to request a wording or content change to one of the transactional emails in this repo. You don't need to write any code — just tell us what should change and why. If you're a member of the team, Claude automatically attempts a draft PR as soon as you submit this issue; someone still reviews it before it merges. Anyone else's request gets triaged by a maintainer first, who can add the `ai-draft` label to have Claude take a pass at it (also the retry path if an automated attempt doesn't work out).
   - type: dropdown
     id: template
     attributes:

--- a/.github/ISSUE_TEMPLATE/new-template-request.yml
+++ b/.github/ISSUE_TEMPLATE/new-template-request.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form to request a brand-new transactional email. You don't need to write any code — describe what the email should say and when it's sent. Claude will automatically attempt a first-draft PR as soon as you submit this issue — it'll still need engineer and brand review before it merges, since a new template involves layout and structure decisions, not just wording. If the automated attempt doesn't work out, a maintainer can add the `ai-draft` label to retry it.
+        Use this form to request a brand-new transactional email. You don't need to write any code — describe what the email should say and when it's sent. If you're a member of the team, Claude automatically attempts a first-draft PR as soon as you submit this issue — it'll still need engineer and brand review before it merges, since a new template involves layout and structure decisions, not just wording. Anyone else's request gets triaged by a maintainer first, who can add the `ai-draft` label to have Claude take a pass at it (also the retry path if an automated attempt doesn't work out).
   - type: input
     id: name
     attributes:

--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -10,9 +10,11 @@
 name: Draft PR for content request
 
 # Fires automatically when a "Content / Wording Change Request" issue is opened
-# (the issue form applies the `content` label at creation). If that run fails
-# or gets a mediocre result, re-trigger it by adding (or re-adding) the
-# `ai-draft` label on the issue — that's the manual retry path.
+# by an org member/collaborator (the issue form applies the `content` label at
+# creation). This repo is public, so an issue opened by anyone else does NOT
+# auto-trigger — a maintainer reviews it and adds the `ai-draft` label to run
+# it manually. That same label also re-triggers a run that failed or fell
+# short, regardless of who opened the issue.
 on:
   issues:
     types: [opened, labeled]
@@ -27,7 +29,10 @@ jobs:
   draft-pr:
     if: >
       contains(github.event.issue.labels.*.name, 'content') &&
-      (github.event.action == 'opened' || github.event.label.name == 'ai-draft')
+      (
+        (github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)) ||
+        (github.event.action == 'labeled' && github.event.label.name == 'ai-draft')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -42,8 +47,6 @@ jobs:
           base_branch: main
           branch_prefix: 'content-request/'
           show_full_output: true
-          claude_args: |
-            --allowedTools "Read,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr create:*)"
           prompt: |
             You're handling GitHub issue #${{ github.event.issue.number }} in this repo, a
             "Content / Wording Change Request" filed via

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -1,10 +1,12 @@
 # Authenticates via Workload Identity Federation (GitHub OIDC -> short-lived
 # Anthropic token) instead of a static ANTHROPIC_API_KEY secret — see the setup
 # steps and repo variables documented at the top of claude-content-request.yml.
-# Fires automatically when a "New Email Template Request" issue is opened (the
-# issue form applies the `new-template` label at creation). If that run fails
-# or gets a mediocre result, re-trigger it by adding (or re-adding) the
-# `ai-draft` label on the issue — that's the manual retry path.
+# Fires automatically when a "New Email Template Request" issue is opened by
+# an org member/collaborator (the issue form applies the `new-template` label
+# at creation). This repo is public, so an issue opened by anyone else does
+# NOT auto-trigger — a maintainer reviews it and adds the `ai-draft` label to
+# run it manually. That same label also re-triggers a run that failed or fell
+# short, regardless of who opened the issue.
 name: Draft PR for new template request
 
 on:
@@ -21,7 +23,10 @@ jobs:
   draft-pr:
     if: >
       contains(github.event.issue.labels.*.name, 'new-template') &&
-      (github.event.action == 'opened' || github.event.label.name == 'ai-draft')
+      (
+        (github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)) ||
+        (github.event.action == 'labeled' && github.event.label.name == 'ai-draft')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -36,8 +41,6 @@ jobs:
           base_branch: main
           branch_prefix: 'new-template/'
           show_full_output: true
-          claude_args: |
-            --allowedTools "Read,Write,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr create:*)"
           prompt: |
             You're handling GitHub issue #${{ github.event.issue.number }} in this repo, a
             "New Email Template Request" filed via

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ A React Email + Tailwind CSS system for building Datum's transactional emails. S
 
 If you just need wording or content changed on an existing email and aren't comfortable opening a PR, open a "Content / Wording Change Request" issue instead (Issues → New issue). Need a brand-new email entirely? Use the "New Email Template Request" issue form instead — same idea, no coding required.
 
-For either kind of request, Claude automatically attempts a draft PR as soon as the issue is opened (see `.github/workflows/claude-content-request.yml` and `.github/workflows/claude-new-template.yml`) — it's still a draft: someone reviews and merges it like any other PR. If that automated attempt fails or falls short, a maintainer can add the `ai-draft` label to the issue to retry it.
+For either kind of request opened by a team member, Claude automatically attempts a draft PR as soon as the issue is opened (see `.github/workflows/claude-content-request.yml` and `.github/workflows/claude-new-template.yml`) — it's still a draft: someone reviews and merges it like any other PR. This repo is public, so requests from anyone outside the team don't auto-trigger; a maintainer reviews them and adds the `ai-draft` label to run Claude on them. That same label re-triggers a run that failed or fell short, regardless of who opened the issue.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

This repo is public. The `issues: opened` auto-trigger from PR #34 had no check on who opened the issue — any GitHub user could open a "Content / Wording Change Request" or "New Email Template Request" issue and it would hand a Claude agent `contents: write`, `pull-requests: write`, and a minted Anthropic token, with no review gate.

- **Restricts the auto-trigger** to issues opened by `OWNER`/`MEMBER`/`COLLABORATOR` (`github.event.issue.author_association`). An issue from anyone else just sits for a maintainer to triage, same as before this feature existed — they add the `ai-draft` label to run Claude on it manually. That label path is unaffected either way (GitHub already restricts who can add labels).
- **Drops the per-workflow `claude_args --allowedTools`** in favor of the shared `.claude/settings.json` — confirmed permission rules merge (not override) across CLI args and project settings, so keeping both was redundant. Added `Write` to the shared file since `claude-new-template` needs it and there's no longer a per-workflow list to grant it separately.
- Updates both workflows' comments, both issue form intros, and CONTRIBUTING.md to describe the trusted-author-only behavior accurately.

## Test plan

- [ ] Merge, confirm a fresh org-authored test issue still auto-triggers — not yet tested via an actual `opened` event; all post-merge test runs so far reused the `ai-draft` label re-add path on the existing issue #33 rather than a fresh issue creation
- [ ] Confirm the tool-permission fix (git/gh commands) still works with `.claude/settings.json` as the sole source, not `claude_args` — partially supported: in the run that led to #36, Claude's own diagnostic message noted "`gh pr create` is already approved," confirming that specific permission was picked up from `.claude/settings.json` alone. The run never reached actual `git add/commit/push` execution (it stalled earlier trying to read the issue body), so that part is still unconfirmed