### PR TITLE
fix: embed issue body directly in AI workflow prompts

### DIFF
--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -53,6 +53,15 @@ jobs:
             .github/ISSUE_TEMPLATE/content-change-request.yml. Read CLAUDE.md at the repo
             root first for how this repo's template/bundle pipeline works.
 
+            Here is the issue verbatim — you do not have a way to fetch it yourself, so
+            this is the only copy of it you'll get:
+
+            ---
+            Title: ${{ github.event.issue.title }}
+
+            ${{ github.event.issue.body }}
+            ---
+
             The issue body has a "Which email template?" dropdown (a human-readable name
             like "User Welcome") and a "What should change?" field describing current vs.
             desired wording.

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -49,6 +49,15 @@ jobs:
             document the exact shape every template must follow and why (the export/YAML
             generation pipeline depends on it).
 
+            Here is the issue verbatim — you do not have a way to fetch it yourself, so
+            this is the only copy of it you'll get:
+
+            ---
+            Title: ${{ github.event.issue.title }}
+
+            ${{ github.event.issue.body }}
+            ---
+
             The issue gives: a template name, what triggers the email, which existing
             template it's most similar to, an optional subject line, the greeting/body/
             button copy, and what variables (props) it needs.


### PR DESCRIPTION
## Summary

Live test on issue #33 (after PR #35 merged) found the actual bug: the run completed without erroring, but Claude explicitly reported it couldn't proceed —

> This repo's `.claude/settings.json` pre-approves only a specific set of commands... but not `gh issue view`, `gh issue comment`, `gh api`, `curl`, or a Node HTTPS shim. Every attempt I've made to read issue #33 ... comes back with "This command requires approval"... So I'm blocked on step 1 — I can't read the issue body.

The prompt referenced `github.event.issue.number` but never actually gave Claude the issue's title/body — it was implicitly expected to fetch it, and correctly wasn't permitted to (nor should it be, that's more surface area than it needs). Claude did the right thing here: it stopped and asked instead of guessing.

Fix: interpolate `github.event.issue.title` and `github.event.issue.body` directly into the prompt via GitHub Actions expressions. No fetch needed at all — the content is already sitting in the event payload.

## Test plan

- [ ] Merge, re-trigger issue #33 with `ai-draft`, confirm Claude now finds the wording change on the first pass without asking for the issue content