### PR TITLE
fix: restore explicit claude_args --allowedTools (settings.json alone isn't enough headlessly)

### DIFF
--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -7,6 +7,12 @@
 # variables -> Actions -> Variables), not secrets — they identify resources, not
 # credentials. Setup (Console federation issuer/rule/service account) is documented at
 # https://platform.claude.com/docs/en/manage-claude/wif-providers/github-actions
+#
+# Tool permissions are granted explicitly here via claude_args --allowedTools,
+# not via .claude/settings.json — confirmed empirically that this action's
+# headless run doesn't honor the project settings file's permissions.allow (every
+# Edit/Bash call stayed gated behind an approval prompt that never comes in CI).
+# .claude/settings.json still matters for local/devcontainer use of `claude`.
 name: Draft PR for content request
 
 # Fires automatically when a "Content / Wording Change Request" issue is opened
@@ -47,6 +53,8 @@ jobs:
           base_branch: main
           branch_prefix: 'content-request/'
           show_full_output: true
+          claude_args: |
+            --allowedTools "Read,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr create:*)"
           prompt: |
             You're handling GitHub issue #${{ github.event.issue.number }} in this repo, a
             "Content / Wording Change Request" filed via

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -41,6 +41,8 @@ jobs:
           base_branch: main
           branch_prefix: 'new-template/'
           show_full_output: true
+          claude_args: |
+            --allowedTools "Read,Write,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr create:*)"
           prompt: |
             You're handling GitHub issue #${{ github.event.issue.number }} in this repo, a
             "New Email Template Request" filed via


### PR DESCRIPTION
## Summary

Live test on issue #33 (after #36 fixed issue-body reading) got further than ever — Claude correctly read the issue, identified `emails/user-waitlist.tsx`, found the exact `signoffClosing: 'Cheers,'` key, and described the correct fix — but never applied it:

> every file-write and git/shell operation in this session is gated behind an approval prompt that hasn't been granted yet

This confirms empirically what was an open question when #35 dropped `claude_args` for `.claude/settings.json` alone: **the project settings file's `permissions.allow` isn't honored by this action's headless run.** Every `Edit`/`Bash` call stayed gated behind an approval prompt nobody is present to grant in CI. (The earlier "`gh pr create` is already approved" note from Claude wasn't real confirmation — that run never got far enough to actually attempt it, so it was just Claude reading the settings file and assuming.)

- Restores explicit `claude_args --allowedTools` on both workflows — the one thing #34's test confirmed actually bypasses the gate.
- `.claude/settings.json` stays as-is for local/devcontainer use of `claude`, just not as the CI path's source of truth. Documented this distinction in a comment.

## Test plan

- [ ] Merge, re-trigger issue #33 one more time, confirm the edit + commit + PR actually happen now