### PR TITLE
Restore PR comment for template screenshots

### DIFF
--- a/.github/workflows/screenshot-templates.yml
+++ b/.github/workflows/screenshot-templates.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: screenshot-templates-${{ github.event.pull_request.number }}
@@ -82,3 +83,35 @@ jobs:
           file_pattern: 'screenshots/*.png'
           commit_user_name: github-actions[bot]
           commit_user_email: github-actions[bot]@users.noreply.github.com
+
+      - name: Build comment body
+        if: steps.changed.outputs.any == 'true'
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          {
+            echo "## 📧 Template screenshots"
+            echo
+            echo "Rendered with each template's preview data. Updates automatically as you push."
+            echo
+            while IFS= read -r name; do
+              echo "**${name}**"
+              echo
+              echo "![${name}](https://github.com/${GITHUB_REPOSITORY}/blob/${HEAD_REF}/screenshots/${name}.png?raw=true)"
+              echo
+            done < /tmp/changed-templates.txt
+          } > /tmp/comment-body.md
+
+      - name: Post or update comment
+        if: steps.changed.outputs.any == 'true'
+        uses: marocchino/sticky-pull-request-comment@v3.0.5
+        with:
+          header: email-template-screenshots
+          path: /tmp/comment-body.md
+
+      - name: Remove stale comment when no templates changed
+        if: steps.changed.outputs.any == 'false'
+        uses: marocchino/sticky-pull-request-comment@v3.0.5
+        with:
+          header: email-template-screenshots
+          delete: true


### PR DESCRIPTION
## Summary

Following up on feedback that the comment-based screenshot UX (removed in #29) was worth keeping. PR #29 replaced the side-branch + PR-comment design with committing screenshots directly onto the PR branch — good for keeping main's README live-embedded, but it dropped the comment entirely, so a reviewer now has to open "Files changed" to see rendered previews instead of seeing them inline in the conversation (confirmed missing on PR #38).

- Restores the sticky PR comment, simplified since there's no side branch to copy into anymore — it references the images already committed directly to the PR's own branch by the existing `git-auto-commit-action` step.
- Adds `pull-requests: write` permission (previously only `contents: write`, since nothing posted comments).
- Both behaviors now coexist: direct commit (for main's README) + PR comment (for reviewer UX).

## Test plan

- [ ] Merge, open a template-changing PR, confirm both the direct commit and the comment show up