### PR TITLE
Authenticate git/PR operations as a dedicated GitHub App instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -13,6 +13,15 @@
 # headless run doesn't honor the project settings file's permissions.allow (every
 # Edit/Bash call stayed gated behind an approval prompt that never comes in CI).
 # .claude/settings.json still matters for local/devcontainer use of `claude`.
+#
+# Git/PR operations authenticate as a dedicated GitHub App (via
+# actions/create-github-app-token), not the default job GITHUB_TOKEN. The
+# WIF setup above only authenticates calls to the Anthropic API — it has
+# nothing to do with GitHub permissions. Requires two repo secrets:
+#   CLAUDE_GH_APP_ID           - the App's ID
+#   CLAUDE_GH_APP_PRIVATE_KEY  - the App's private key (PEM)
+# The App needs to be installed on this repo with Contents: write,
+# Pull requests: write, and Issues: write permissions.
 name: Draft PR for content request
 
 # Fires automatically when a "Content / Wording Change Request" issue is opened
@@ -43,8 +52,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Mint GitHub App installation token for git/PR operations
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_GH_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_GH_APP_PRIVATE_KEY }}
+
       - uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.app-token.outputs.token }}
           anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
           anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -1,6 +1,9 @@
 # Authenticates via Workload Identity Federation (GitHub OIDC -> short-lived
 # Anthropic token) instead of a static ANTHROPIC_API_KEY secret — see the setup
 # steps and repo variables documented at the top of claude-content-request.yml.
+# Git/PR operations authenticate as a dedicated GitHub App instead of the
+# default job GITHUB_TOKEN — see the same file's comment for the required
+# CLAUDE_GH_APP_ID / CLAUDE_GH_APP_PRIVATE_KEY secrets and App permissions.
 # Fires automatically when a "New Email Template Request" issue is opened by
 # an org member/collaborator (the issue form applies the `new-template` label
 # at creation). This repo is public, so an issue opened by anyone else does
@@ -31,8 +34,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Mint GitHub App installation token for git/PR operations
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_GH_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_GH_APP_PRIVATE_KEY }}
+
       - uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ steps.app-token.outputs.token }}
           anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
           anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

WIF only authenticates calls to the Anthropic API (letting Claude think/generate) — it has nothing to do with GitHub permissions. Both `claude-*.yml` workflows have been relying on the default job `GITHUB_TOKEN` for all git/PR operations this whole time. The `claude[bot]` name/email visible on commit authorship is just git config the action sets before committing — cosmetic, not proof of which token actually authenticated the push.

This matters because the `GITHUB_TOKEN` path is likely what's behind the CI-approval-gate friction seen on PR #38 (a secondary run attributed to `github-actions[bot]` needed manual approval). A dedicated GitHub App with real, explicit permissions on this repo should be treated as trusted the same way a human collaborator with write access is.

- Adds a step using `actions/create-github-app-token` to mint an installation token from a dedicated GitHub App
- Passes that token to `claude-code-action`'s `github_token` input, so all git/PR/comment operations authenticate as the App instead of the default token
- Documented in both workflow files what's needed to activate this

## Before this can go live

- A GitHub App needs to be created and installed on this repo with **Contents: write**, **Pull requests: write**, and **Issues: write** permissions
- Two repo secrets need to be set: `CLAUDE_GH_APP_ID` (the App's ID) and `CLAUDE_GH_APP_PRIVATE_KEY` (the App's private key, PEM format)

## Test plan

- [ ] Once the App is set up and secrets are added, re-trigger a test issue and confirm the PR now authenticates as the new App
- [ ] Confirm the CI-approval-gate friction from PR #38 is actually resolved (or isn't — in which case the gate is unrelated to token identity and something else entirely)

Part of #18