### PR TITLE
feat: new-template AI drafts also update README and issue dropdown

### DIFF
--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -92,8 +92,13 @@ jobs:
                .github/ISSUE_TEMPLATE/new-template-request.yml's `closest_existing` dropdown
                (insert alphabetically-ish alongside the existing options, before "Not sure"),
                so future new-template requests can reference it.
-            6. Don't modify emails/components/, emails/layouts/, emails/config/, any existing
-               template, or any file outside the ones named in steps 1, 4, and 5.
+            6. Prefer not touching anything else, but you may add to or adjust
+               emails/components/ or emails/layouts/ if the template genuinely can't be
+               built from what already exists there (e.g. it needs a new shared block, or an
+               existing component needs a new variant) — don't duplicate a whole component
+               just to avoid editing the shared one. Do not touch emails/config/ (Tailwind/
+               brand config), any existing template's content, or any file outside the ones
+               named in steps 1, 4, 5, and this one.
             7. Run `pnpm generate:all` to regenerate config/email-templates/ and confirm it
                picks up the new template, and `pnpm check` to confirm Biome is clean. Include
                the regenerated config/email-templates/ output in your commit.

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -80,12 +80,24 @@ jobs:
                why: the generator extracts `.Subject` via a regex expecting a literal
                quoted string right there, and a variable reference makes it silently fall
                back to a generic subject.
-            4. Only add this one new file. Do not modify emails/components/, emails/layouts/,
-               emails/config/, any existing template, or any file outside emails/.
-            5. Run `pnpm generate:all` to regenerate config/email-templates/ and confirm it
+            4. Add a `<details>` entry for the new template to README.md's "Emails in this
+               repo" section, in the same position/style as the existing entries (a
+               `<summary>` with a bold name and a short one-line description in the same
+               voice as the others, then `<img src="./screenshots/<name>.png" width="480" />`
+               using the kebab-case file name from step 1). The screenshot itself doesn't
+               exist yet — a separate workflow (screenshot-templates.yml) generates and
+               commits it onto this same PR branch once opened, so the `<img>` tag will
+               start resolving once that runs; don't try to generate the PNG yourself.
+            5. Add the new template's human-readable name as an option in
+               .github/ISSUE_TEMPLATE/new-template-request.yml's `closest_existing` dropdown
+               (insert alphabetically-ish alongside the existing options, before "Not sure"),
+               so future new-template requests can reference it.
+            6. Don't modify emails/components/, emails/layouts/, emails/config/, any existing
+               template, or any file outside the ones named in steps 1, 4, and 5.
+            7. Run `pnpm generate:all` to regenerate config/email-templates/ and confirm it
                picks up the new template, and `pnpm check` to confirm Biome is clean. Include
                the regenerated config/email-templates/ output in your commit.
-            6. Open a PR against main with a clear title and a body that says
+            8. Open a PR against main with a clear title and a body that says
                "Closes #${{ github.event.issue.number }}", summarizes what you scaffolded,
                and explicitly flags that this is a first draft — exact copy, brand colors,
                and any legal/compliance boilerplate still need human review before merge.


### PR DESCRIPTION
## Summary
Previously the new-template automation (`claude-new-template.yml`) was explicitly scoped to add *only* the new `emails/*.tsx` file, which meant every AI-drafted new template still needed a human to:
- Add its `<details>`/screenshot entry to `README.md`'s "Emails in this repo" section
- Add it as an option in `.github/ISSUE_TEMPLATE/new-template-request.yml`'s "closest existing" dropdown

This updates the prompt so Claude does both as part of the same draft PR:
- Adds a matching `<details>` block to README.md (the screenshot itself still comes from `screenshot-templates.yml` running on the PR — the `<img>` tag just starts resolving once that lands)
- Adds the new template name to the issue form's dropdown, so future requests can reference it

## Test plan
- [ ] Open a real "New Email Template Request" issue and confirm the resulting draft PR includes the README entry and dropdown update alongside the template file
- [ ] Confirm `screenshot-templates.yml` picks up the new template and the README `<img>` resolves once its commit lands

Part of #18