### PR TITLE
feat: comment on the issue linking the PR once a draft is ready

### DIFF
--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -54,7 +54,7 @@ jobs:
           branch_prefix: 'content-request/'
           show_full_output: true
           claude_args: |
-            --allowedTools "Read,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr create:*)"
+            --allowedTools "Read,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr create:*),Bash(gh issue comment:*)"
           prompt: |
             You're handling GitHub issue #${{ github.event.issue.number }} in this repo, a
             "Content / Wording Change Request" filed via
@@ -91,6 +91,9 @@ jobs:
             5. Open a PR against main with a clear title and a body that says
                "Closes #${{ github.event.issue.number }}", quoting the before/after
                wording.
+            6. Comment on issue #${{ github.event.issue.number }} (via `gh issue comment`)
+               linking the PR you just opened and @-mentioning
+               ${{ github.event.issue.user.login }} to let them know it's ready for review.
 
             If the request is ambiguous, spans multiple unrelated strings, or isn't a
             simple wording swap (e.g. asks for new sections, new templates, or layout

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -42,7 +42,7 @@ jobs:
           branch_prefix: 'new-template/'
           show_full_output: true
           claude_args: |
-            --allowedTools "Read,Write,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr create:*)"
+            --allowedTools "Read,Write,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr create:*),Bash(gh issue comment:*)"
           prompt: |
             You're handling GitHub issue #${{ github.event.issue.number }} in this repo, a
             "New Email Template Request" filed via
@@ -89,6 +89,9 @@ jobs:
                "Closes #${{ github.event.issue.number }}", summarizes what you scaffolded,
                and explicitly flags that this is a first draft — exact copy, brand colors,
                and any legal/compliance boilerplate still need human review before merge.
+            7. Comment on issue #${{ github.event.issue.number }} (via `gh issue comment`)
+               linking the PR you just opened and @-mentioning
+               ${{ github.event.issue.user.login }} to let them know it's ready for review.
 
             This is a more open-ended task than a wording tweak: you're making layout and
             structure choices, not just swapping a string. If the request is too vague to


### PR DESCRIPTION
## Summary
Both AI workflows (`claude-content-request.yml`, `claude-new-template.yml`) only commented back on the originating issue when they *couldn't* draft confidently. On success, they opened the PR (with `Closes #N` in the body) but never posted anything back on the issue itself — so the requester had no notification that their request was ready for review.

- Adds a final step to both prompts: after opening the PR, comment on the issue linking it and @-mentioning the issue's author
- Adds `Bash(gh issue comment:*)` to both workflows' `--allowedTools` (previously missing — the existing "comment on the issue for clarification" instruction likely wasn't actually able to run)

## Test plan
- [ ] Open a real content-change or new-template request issue and confirm a comment appears on the issue linking the resulting PR and mentioning the author

Part of #18