### PR TITLE
fix: set up Node/pnpm before the AI draft workflows run

### DIFF
--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -22,6 +22,11 @@
 #   CLAUDE_GH_APP_PRIVATE_KEY  - the App's private key (PEM)
 # The App needs to be installed on this repo with Contents: write,
 # Pull requests: write, and Issues: write permissions.
+#
+# Node/pnpm are set up and `pnpm install` runs before Claude starts — without
+# this, `pnpm generate:all`/`pnpm check` have no node_modules to work with, and
+# Claude has no way to install them itself (npm/corepack/network access aren't
+# in --allowedTools, and shouldn't be added just to work around this).
 name: Draft PR for content request
 
 # Fires automatically when a "Content / Wording Change Request" issue is opened
@@ -58,6 +63,17 @@ jobs:
         with:
           app-id: ${{ secrets.CLAUDE_GH_APP_ID }}
           private-key: ${{ secrets.CLAUDE_GH_APP_PRIVATE_KEY }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -4,6 +4,8 @@
 # Git/PR operations authenticate as a dedicated GitHub App instead of the
 # default job GITHUB_TOKEN — see the same file's comment for the required
 # CLAUDE_GH_APP_ID / CLAUDE_GH_APP_PRIVATE_KEY secrets and App permissions.
+# Node/pnpm are set up and `pnpm install` runs before Claude starts — see
+# claude-content-request.yml's comment for why this is required, not optional.
 # Fires automatically when a "New Email Template Request" issue is opened by
 # an org member/collaborator (the issue form applies the `new-template` label
 # at creation). This repo is public, so an issue opened by anyone else does
@@ -40,6 +42,17 @@ jobs:
         with:
           app-id: ${{ secrets.CLAUDE_GH_APP_ID }}
           private-key: ${{ secrets.CLAUDE_GH_APP_PRIVATE_KEY }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary
Confirmed via a live end-to-end test (issues #47, #48): neither `claude-content-request.yml` nor `claude-new-template.yml` ever set up Node/pnpm or ran `pnpm install` — a gap flagged earlier but never fixed. With no `node_modules`, `pnpm generate:all`/`pnpm check` had nothing to run against, and Claude's own attempts to install dependencies (`npm install`, `corepack`, `curl`) were correctly blocked since none of those are in `--allowedTools`.

Concretely, this caused:
- Issue #47 (content change): Claude made the correct source edit but couldn't run `pnpm generate:all`, so it declined to open a PR at all rather than commit a stale/hand-guessed bundle — an honest failure, but a failure.
- Issue #48 (new template): Claude worked around it by skipping `pnpm generate:all`/`pnpm check` locally and leaving `config/email-templates/` to `verify-bundle.yml`'s auto-commit — which did work, but that's a lucky safety net, not the intended flow, and left the branch in a broken state until the auto-commit landed.

Adds the same `actions/setup-node` + `pnpm/action-setup` + `pnpm install --frozen-lockfile` steps `verify-bundle.yml`/`screenshot-templates.yml` already use, before Claude starts, to both workflows.

## Test plan
- [ ] Re-run the content-change and new-template test flows and confirm `pnpm generate:all`/`pnpm check` succeed inline, with no reliance on CI auto-commit to fill in `config/email-templates/`

Part of #18