### PR TITLE
docs: correct stale draft-PR phrasing in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ A React Email + Tailwind CSS system for building Datum's transactional emails. S
 
 If you just need wording or content changed on an existing email and aren't comfortable opening a PR, open a "Content / Wording Change Request" issue instead (Issues → New issue). Need a brand-new email entirely? Use the "New Email Template Request" issue form instead — same idea, no coding required.
 
-For either kind of request opened by a team member, Claude automatically attempts a draft PR as soon as the issue is opened (see `.github/workflows/claude-content-request.yml` and `.github/workflows/claude-new-template.yml`) — it's still a draft: someone reviews and merges it like any other PR. This repo is public, so requests from anyone outside the team don't auto-trigger; a maintainer reviews them and adds the `ai-draft` label to run Claude on them. That same label re-triggers a run that failed or fell short, regardless of who opened the issue.
+For either kind of request opened by a team member, Claude automatically opens a first-pass PR as soon as the issue is opened (see `.github/workflows/claude-content-request.yml` and `.github/workflows/claude-new-template.yml`), with the `datum-cloud/gtm` team requested as reviewer and a screenshot of the rendered template posted as a comment — someone still reviews and merges it like any other PR. This repo is public, so requests from anyone outside the team don't auto-trigger; a maintainer reviews them and adds the `ai-draft` label to run Claude on them. That same label re-triggers a run that failed or fell short, regardless of who opened the issue.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
Confirmed via live end-to-end testing that AI-drafted PRs are explicitly non-draft (`gh pr create` never passes `--draft`) and now request the `datum-cloud/gtm` team as reviewer, with a screenshot posted as a comment. CONTRIBUTING.md's wording ("it's still a draft") was ambiguous and didn't mention either of those.

## Test plan
- [ ] N/A — docs only

Part of #18