### PR TITLE
fix: write AI-drafted PR bodies/comments for a non-technical GTM audience

### DIFF
--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -121,14 +121,26 @@ jobs:
             4. Run `pnpm generate:all` to regenerate config/email-templates/ from your
                change, and `pnpm check` to confirm Biome is still clean. Include the
                regenerated config/email-templates/ output in your commit.
-            5. Open a PR against main (not a draft) with a clear title and a body that says
-               "Closes #${{ github.event.issue.number }}", quoting the before/after
-               wording. Request review from the `datum-cloud/gtm` team (e.g. `gh pr create
+            5. Open a PR against main (not a draft) with a clear title. The reviewer is
+               GTM, not an engineer, so write the body in plain language, not repo/tooling
+               jargon:
+                 - Lead with "Closes #${{ github.event.issue.number }}", then a
+                   before/after quote of the wording — that's the part they actually need
+                   to check.
+                 - Mention that a screenshot of the rendered email will show up as a
+                   separate PR comment shortly.
+                 - Do NOT mention file paths, `pnpm`, "regenerated YAML", Biome, or any
+                   other implementation detail in the main body. If you want to record
+                   that for engineers, put it inside a collapsed
+                   `<details><summary>Technical details</summary>...</details>` block at
+                   the end, not in the main text.
+               Request review from the `datum-cloud/gtm` team (e.g. `gh pr create
                --reviewer datum-cloud/gtm ...`) — they own email content and can merge this
                without needing an engineering approval.
             6. Comment on issue #${{ github.event.issue.number }} (via `gh issue comment`)
                linking the PR you just opened and @-mentioning
-               ${{ github.event.issue.user.login }} to let them know it's ready for review.
+               ${{ github.event.issue.user.login }}. Keep it short and non-technical: it's
+               ready for the GTM team to review, here's the link, that's it.
 
             If the request is ambiguous, spans multiple unrelated strings, or isn't a
             simple wording swap (e.g. asks for new sections, new templates, or layout

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -126,16 +126,28 @@ jobs:
             7. Run `pnpm generate:all` to regenerate config/email-templates/ and confirm it
                picks up the new template, and `pnpm check` to confirm Biome is clean. Include
                the regenerated config/email-templates/ output in your commit.
-            8. Open a PR against main (not a draft) with a clear title and a body that says
-               "Closes #${{ github.event.issue.number }}", summarizes what you scaffolded,
-               and explicitly flags that this is a first draft — exact copy, brand colors,
-               and any legal/compliance boilerplate still need human review before merge.
+            8. Open a PR against main (not a draft) with a clear title. The reviewer is
+               GTM, not an engineer, so write the body in plain language, not repo/tooling
+               jargon:
+                 - Lead with "Closes #${{ github.event.issue.number }}", then a short,
+                   plain description of the new email — what it says, when it's sent —
+                   not a file-by-file list of what you touched.
+                 - Mention that a screenshot of the rendered email will show up as a
+                   separate PR comment shortly.
+                 - Explicitly flag it as a first draft: exact copy, brand colors, and any
+                   legal/compliance wording still need human review before merge.
+                 - Do NOT mention file paths, `pnpm`, "regenerated YAML", Biome, dropdown
+                   options, or other implementation detail in the main body. If you want
+                   to record that for engineers, put it inside a collapsed
+                   `<details><summary>Technical details</summary>...</details>` block at
+                   the end, not in the main text.
                Request review from the `datum-cloud/gtm` team (e.g. `gh pr create --reviewer
                datum-cloud/gtm ...`) — they own email content and can merge this without
                needing an engineering approval.
             9. Comment on issue #${{ github.event.issue.number }} (via `gh issue comment`)
                linking the PR you just opened and @-mentioning
-               ${{ github.event.issue.user.login }} to let them know it's ready for review.
+               ${{ github.event.issue.user.login }}. Keep it short and non-technical: it's
+               ready for the GTM team to review, here's the link, that's it.
 
             This is a more open-ended task than a wording tweak: you're making layout and
             structure choices, not just swapping a string. If the request is too vague to


### PR DESCRIPTION
## Summary
Live-tested PRs (#58, #59) confirmed the bug: PR bodies and issue \"ready for review\" comments were full of repo/tooling jargon — file paths, `pnpm generate:all`, Biome, \"regenerated YAML\", dropdown internals, `MainLayout`/`CustomButton` — despite GTM (not engineering) being the intended reviewer.

Updates both prompts so:
- The PR body leads with the before/after wording (content) or a plain description of what the email says and when it's sent (new template) — not a file-by-file technical changelog.
- Implementation details, if worth recording, go in a collapsed `<details><summary>Technical details</summary>` block instead of the main body.
- The issue comment is just: ready for GTM review, here's the link.

## Test plan
- [ ] Re-run the example issues (#55, #56) and confirm the resulting PR bodies read like something a GTM reviewer would want, not an engineering changelog

Part of #18