### PR TITLE
fix: attribute Claude's commits to our GitHub App, not github-actions[bot]

### DIFF
--- a/.github/workflows/claude-content-request.yml
+++ b/.github/workflows/claude-content-request.yml
@@ -23,6 +23,13 @@
 # The App needs to be installed on this repo with Contents: write,
 # Pull requests: write, and Issues: write permissions.
 #
+# claude-code-action's bot_id/bot_name inputs are also set to this App's
+# identity — its own default (bot_id 41898282, "claude[bot]") is a known bug
+# (anthropics/claude-code-action#759): that ID actually belongs to GitHub's
+# real github-actions[bot] account, so without overriding it, every commit
+# Claude makes gets attributed to github-actions[bot] in GitHub's UI even
+# though the PR itself is correctly opened by our App.
+#
 # Node/pnpm are set up and `pnpm install` runs before Claude starts — without
 # this, `pnpm generate:all`/`pnpm check` have no node_modules to work with, and
 # Claude has no way to install them itself (npm/corepack/network access aren't
@@ -78,6 +85,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
+          bot_id: '306493438'
+          bot_name: 'datum-email-designer[bot]'
           anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
           anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}

--- a/.github/workflows/claude-new-template.yml
+++ b/.github/workflows/claude-new-template.yml
@@ -57,6 +57,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
+          bot_id: '306493438'
+          bot_name: 'datum-email-designer[bot]'
           anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
           anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
Confirmed the PR itself was always correctly opened by our `datum-email-designer` App (`gh pr view --json author` → `app/datum-email-designer`), but the individual git commit Claude makes inside the PR showed up as authored by `github-actions[bot]` instead.

Root cause: `claude-code-action`'s commit-author identity defaults to `bot_id: "41898282"` / `bot_name: "claude[bot]"` — and `41898282` is actually GitHub's real `github-actions[bot]` account ID, not a genuine "claude[bot]" account. This is a known upstream bug ([anthropics/claude-code-action#759](https://github.com/anthropics/claude-code-action/issues/759)). Since we don't override it, every commit Claude makes gets attributed to `github-actions[bot]` in GitHub's UI.

Fix: explicitly pass `bot_id: '306493438'` / `bot_name: 'datum-email-designer[bot]'` (our App's real ID, confirmed via `gh api users/datum-email-designer[bot]`) to both `claude-content-request.yml` and `claude-new-template.yml`, matching the identity already used correctly by the screenshot workflow's auto-commits.

## Test plan
- [ ] Re-run one of the example issues and confirm the resulting commit (not just the PR) is attributed to `datum-email-designer[bot]`

Part of #18