### PR TITLE
fix: authenticate auto-commit workflows as our GitHub App to skip the approval gate

### DIFF
--- a/.github/workflows/screenshot-templates.yml
+++ b/.github/workflows/screenshot-templates.yml
@@ -1,3 +1,7 @@
+# Auto-commits here authenticate as the datum-email-designer GitHub App instead
+# of the default GITHUB_TOKEN — see verify-bundle.yml's comment for why (a
+# push from the default GITHUB_TOKEN gets subsequent workflow runs on the same
+# PR gated behind a manual "action_required" approval).
 name: Screenshot Changed Templates
 
 on:
@@ -18,11 +22,19 @@ jobs:
   screenshot:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint GitHub App installation token for git operations
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_GH_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_GH_APP_PRIVATE_KEY }}
+
       - name: Checkout PR branch
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -81,8 +93,8 @@ jobs:
         with:
           commit_message: "chore: update template screenshots"
           file_pattern: 'screenshots/*.png'
-          commit_user_name: github-actions[bot]
-          commit_user_email: github-actions[bot]@users.noreply.github.com
+          commit_user_name: datum-email-designer[bot]
+          commit_user_email: 306493438+datum-email-designer[bot]@users.noreply.github.com
 
       - name: Build comment body
         if: steps.changed.outputs.any == 'true'

--- a/.github/workflows/verify-bundle.yml
+++ b/.github/workflows/verify-bundle.yml
@@ -1,3 +1,10 @@
+# Auto-commits here authenticate as the datum-email-designer GitHub App instead
+# of the default GITHUB_TOKEN. Confirmed empirically: a synchronize event whose
+# push comes from the default GITHUB_TOKEN (committer github-actions[bot]) gets
+# gated behind a manual "action_required" approval on every subsequent
+# workflow run on that PR, while the same push authenticated as our App does
+# not. Requires the same CLAUDE_GH_APP_ID / CLAUDE_GH_APP_PRIVATE_KEY secrets
+# used by claude-content-request.yml / claude-new-template.yml.
 name: Verify Kustomize Bundle
 
 on:
@@ -15,11 +22,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Mint GitHub App installation token for git operations
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_GH_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_GH_APP_PRIVATE_KEY }}
+
       - name: Checkout PR branch
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -40,8 +55,8 @@ jobs:
         with:
           commit_message: "chore: regenerate email template bundle"
           file_pattern: 'config/email-templates/**'
-          commit_user_name: github-actions[bot]
-          commit_user_email: github-actions[bot]@users.noreply.github.com
+          commit_user_name: datum-email-designer[bot]
+          commit_user_email: 306493438+datum-email-designer[bot]@users.noreply.github.com
 
   validate-kustomize:
     permissions:


### PR DESCRIPTION
## Summary
Root cause confirmed, with screenshot evidence from the repo's Settings → Actions page: **"Approval for running fork pull request workflows from contributors"** is set to "Require approval for first-time contributors," and per GitHub's own description, this checks *both* the PR author *and* the actor of the triggering event — not just forked PRs. `git-auto-commit-action`'s default committer identity, `github-actions[bot]`, has no recognized commit/PR history of its own, so every `pull_request: synchronize` event it triggers (by pushing an auto-commit) gets treated as a first-time-contributor event and gated behind manual approval — even on a same-repo, non-fork branch. Our GitHub App doesn't hit this, since it has real installed write access, which is why every App-triggered run has gone through clean in testing.

Fix: `verify-bundle.yml` and `screenshot-templates.yml` now mint an installation token for the same `datum-email-designer` App (reusing `CLAUDE_GH_APP_ID`/`CLAUDE_GH_APP_PRIVATE_KEY`) and use it for `actions/checkout` + the auto-commit's author identity, instead of the default `GITHUB_TOKEN`.

## Test plan
- [ ] Push a template change and confirm neither workflow's *second* run (the one triggered by its own auto-commit) requires manual approval