### PR TITLE
fix: release workflow doesn't publish a bundle, ignores bump on first release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,20 @@ jobs:
     permissions:
       contents: write
     steps:
+      # softprops/action-gh-release needs to authenticate as our GitHub App,
+      # not the default GITHUB_TOKEN: GitHub deliberately blocks the default
+      # token from triggering other workflow runs (loop prevention), which
+      # means a release created with it never fires publish-kustomize-bundle.yml's
+      # `on: release: types: [published]` — the release exists but no
+      # versioned OCI bundle ever gets published for it. Same class of issue
+      # already fixed for the auto-commit workflows (see verify-bundle.yml).
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_GH_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_GH_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -28,17 +42,16 @@ jobs:
         id: version
         run: |
           LATEST=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-          if [ -z "${LATEST}" ]; then
-            NEXT="v0.1.0"
-          else
-            IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST#v}"
-            case "${{ inputs.bump }}" in
-              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
-              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
-              patch) PATCH=$((PATCH + 1)) ;;
-            esac
-            NEXT="v${MAJOR}.${MINOR}.${PATCH}"
-          fi
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST#v}"
+          MAJOR="${MAJOR:-0}"
+          MINOR="${MINOR:-0}"
+          PATCH="${PATCH:-0}"
+          case "${{ inputs.bump }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+          NEXT="v${MAJOR}.${MINOR}.${PATCH}"
           echo "Previous version: ${LATEST:-none}"
           echo "Next version: ${NEXT}"
           echo "tag=${NEXT}" >> "$GITHUB_OUTPUT"
@@ -46,6 +59,7 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v3
         with:
+          token: ${{ steps.app-token.outputs.token }}
           tag_name: ${{ steps.version.outputs.tag }}
           target_commitish: main
           generate_release_notes: true


### PR DESCRIPTION
## Summary
Found both of these by actually running "Publish New Version" for the first time (produced `v0.1.0` with no bundle behind it, despite selecting "major"):

- `softprops/action-gh-release` authenticated with the default `GITHUB_TOKEN`. GitHub deliberately blocks the default token from triggering other workflow runs (loop prevention), so the release it created never fired `publish-kustomize-bundle.yml`'s `on: release: types: [published]` — the release existed but no matching OCI bundle was ever published for it. Now mints and uses the same GitHub App token the other workflows already use.
- The version-compute step hardcoded `v0.1.0` whenever no prior tag existed, ignoring whatever bump was selected. Now treats a missing tag as `v0.0.0` and runs it through the same major/minor/patch arithmetic as every later release, so a first release honors the selected bump (e.g. major → `v1.0.0`).

## Test plan
- [ ] Delete the orphan `v0.1.0` tag/release (no OCI bundle behind it) and re-run "Publish New Version" with `bump: major` — confirm it produces `v1.0.0` and a matching `v1.0.0` OCI bundle actually gets published.