### PR TITLE
fix: pin react-email to match @react-email/ui, fixing pnpm dev

### DIFF
--- a/config/email-templates/platforminvitation-emailtemplate.yaml
+++ b/config/email-templates/platforminvitation-emailtemplate.yaml
@@ -121,7 +121,7 @@ spec:
                                         style="line-height:20px;text-decoration:none;display:block;max-width:100%;mso-padding-alt:0px;border-radius:0.25rem;font-weight:600;text-align:center;text-decoration-line:none;border-style:solid;border-width:1px;background-color:rgb(191,149,149);color:rgb(255,255,255);border-color:rgb(191,149,149);padding-right:24px;padding-left:24px;padding-bottom:14px;padding-top:14px;font-size:16px;margin-top:36px;margin-bottom:32px"
                                         target="_blank"
                                         ><span
-                                          ><!--[if mso]><i style="mso-font-width:400%;mso-text-raise:21" hidden>&#8202;&#8202;&#8202;</i><![endif]--></span
+                                          ><!--[if mso]><i style="mso-font-width:400%;mso-text-raise:21px" hidden>&#8202;&#8202;&#8202;</i><![endif]--></span
                                         ><span
                                           style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:10.5px"
                                           >Get started</span

--- a/config/email-templates/userapproved-emailtemplate.yaml
+++ b/config/email-templates/userapproved-emailtemplate.yaml
@@ -110,7 +110,7 @@ spec:
                                         style="line-height:20px;text-decoration:none;display:block;max-width:100%;mso-padding-alt:0px;border-radius:0.25rem;font-weight:600;text-align:center;text-decoration-line:none;border-style:solid;border-width:1px;background-color:rgb(191,149,149);color:rgb(255,255,255);border-color:rgb(191,149,149);padding-right:24px;padding-left:24px;padding-bottom:14px;padding-top:14px;font-size:16px;margin-top:36px;margin-bottom:32px"
                                         target="_blank"
                                         ><span
-                                          ><!--[if mso]><i style="mso-font-width:400%;mso-text-raise:21" hidden>&#8202;&#8202;&#8202;</i><![endif]--></span
+                                          ><!--[if mso]><i style="mso-font-width:400%;mso-text-raise:21px" hidden>&#8202;&#8202;&#8202;</i><![endif]--></span
                                         ><span
                                           style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:10.5px"
                                           >Start building</span

--- a/config/email-templates/userinvitation-emailtemplate.yaml
+++ b/config/email-templates/userinvitation-emailtemplate.yaml
@@ -125,7 +125,7 @@ spec:
                                         style="line-height:20px;text-decoration:none;display:block;max-width:100%;mso-padding-alt:0px;border-radius:0.25rem;font-weight:600;text-align:center;text-decoration-line:none;border-style:solid;border-width:1px;background-color:rgb(191,149,149);color:rgb(255,255,255);border-color:rgb(191,149,149);padding-right:24px;padding-left:24px;padding-bottom:14px;padding-top:14px;font-size:16px;margin-top:36px;margin-bottom:32px"
                                         target="_blank"
                                         ><span
-                                          ><!--[if mso]><i style="mso-font-width:400%;mso-text-raise:21" hidden>&#8202;&#8202;&#8202;</i><![endif]--></span
+                                          ><!--[if mso]><i style="mso-font-width:400%;mso-text-raise:21px" hidden>&#8202;&#8202;&#8202;</i><![endif]--></span
                                         ><span
                                           style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:10.5px"
                                           >Accept invitation</span

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-email": "6.5.0",
+    "react-email": "6.9.0",
     "web-streams-polyfill": "^4.3.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
       react-email:
-        specifier: 6.5.0
-        version: 6.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 6.9.0
+        version: 6.9.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       web-streams-polyfill:
         specifier: ^4.3.0
         version: 4.3.0
@@ -50,6 +50,10 @@ packages:
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -58,8 +62,8 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.27.0':
-    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -72,8 +76,8 @@ packages:
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.27.0':
-    resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -707,10 +711,6 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
-  globals@11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
-    engines: {node: '>=4'}
-
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -725,8 +725,8 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
-  jiti@2.4.2:
-    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   js-tokens@4.0.0:
@@ -900,8 +900,8 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
-  react-email@6.5.0:
-    resolution: {integrity: sha512-WrJ+XPW87O1dabF4RJNGnTr7VTGsNa+BlMiinAZdH5fg8Kepwk++ZzX+LEieTlk+a3r13TaTJ4DfI9gv++y02g==}
+  react-email@6.9.0:
+    resolution: {integrity: sha512-72jV+VkeeXgNWDycNDn2tIlHFLg4Hevi3pC77g63FAY1+bDgTs4b56jbZfHF1t5d+GVGb02sGS8bOwoptgvI1w==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -1053,11 +1053,13 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/helper-globals@7.29.7': {}
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/parser@7.27.0':
+  '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.7
 
@@ -1071,15 +1073,15 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.27.0':
+  '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
-      '@babel/parser': 7.27.0
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
       debug: 4.4.3
-      globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1571,8 +1573,6 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  globals@11.12.0: {}
-
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -1592,7 +1592,7 @@ snapshots:
 
   is-unicode-supported@2.1.0: {}
 
-  jiti@2.4.2: {}
+  jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -1727,10 +1727,10 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
-  react-email@6.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-email@6.9.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@babel/parser': 7.27.0
-      '@babel/traverse': 7.27.0
+      '@babel/parser': 7.29.2
+      '@babel/traverse': 7.29.0
       '@react-email/render': 2.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       chokidar: 4.0.3
       commander: 13.1.0
@@ -1739,7 +1739,7 @@ snapshots:
       debounce: 2.2.0
       esbuild: 0.28.1
       glob: 13.0.6
-      jiti: 2.4.2
+      jiti: 2.6.1
       log-symbols: 7.0.1
       marked: 15.0.12
       mime-types: 3.0.2


### PR DESCRIPTION
## Summary
Found while verifying the documented dev setup works through `.devcontainer` (per [#18](https://github.com/datum-cloud/email-templates/issues/18)): the dependency bump in #73 moved `@react-email/ui` to `^6.9.0` but left `react-email` pinned at an exact `6.5.0`. The `email` CLI detects that version mismatch and blocks `pnpm dev` on an interactive "install the matching version? (Y/n)" prompt — which just hangs forever with no output in any non-interactive environment (devcontainer, CI, Codespaces), and is easy to miss locally since a terminal just shows a prompt rather than an obvious failure.

Bumps `react-email` to `6.9.0` to match. Regenerated `config/email-templates/` since the bump tweaks an MSO-conditional button style attribute (adds a `px` unit suffix — cosmetic Outlook-only styling, not a visible change in any real client).

## Test plan
- [x] Fresh `.devcontainer` build (via `devcontainer up`) from a clean clone
- [x] `pnpm install` via the container's `postCreateCommand`
- [x] `pnpm dev` — starts cleanly, serves 200 on :3000, no prompt
- [x] `pnpm generate:all`
- [x] `pnpm check`
- [x] `pnpm screenshot`