### PR TITLE
feat: let maintainers revise a draft via @claude comments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,9 +20,12 @@
 /config/email-templates/ @datum-cloud/gtm
 /screenshots/ @datum-cloud/gtm
 
-# The new-template-request AI draft flow updates both of these alongside the
-# template itself (the README's template list, the issue form's "closest
-# existing" dropdown) — GTM-owned so those draft PRs don't need an engineering
-# approval just for touching them.
-/README.md @datum-cloud/gtm
+# The new-template-request AI draft flow updates the README's template list
+# alongside the template itself, so GTM stays an owner here (an approval from
+# either team satisfies review — this doesn't force an engineering approval
+# onto those draft PRs). README.md and CONTRIBUTING.md are the shared
+# contributor-facing docs for the whole repo (setup, pipeline, release
+# process), not just template content, so engineering co-owns both.
+/README.md @datum-cloud/gtm @datum-cloud/engineering
+/CONTRIBUTING.md @datum-cloud/gtm @datum-cloud/engineering
 /.github/ISSUE_TEMPLATE/new-template-request.yml @datum-cloud/gtm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,12 +7,15 @@
 # their AI-assisted draft PRs) edit.
 /emails/*.tsx @datum-cloud/gtm
 
-# Shared components/layouts are also GTM's — the new-template-request AI draft
-# flow is allowed to touch these when a new template genuinely needs a new or
-# adjusted shared piece, not just its own file. emails/config/ (Tailwind/brand
-# config) stays engineering's above, since it isn't part of that flow.
-/emails/components/ @datum-cloud/gtm
-/emails/layouts/ @datum-cloud/gtm
+# Shared components/layouts are real shared TypeScript, not copy — a mistake
+# here (a broken export, a bad prop type) affects every template, not just
+# one, so engineering co-owns alongside GTM. The new-template-request AI draft
+# flow is still allowed to touch these when a new template genuinely needs a
+# new or adjusted shared piece, not just its own file. emails/config/
+# (Tailwind/brand config) stays engineering-only above, since it isn't part
+# of that flow.
+/emails/components/ @datum-cloud/gtm @datum-cloud/engineering
+/emails/layouts/ @datum-cloud/gtm @datum-cloud/engineering
 
 # Auto-generated from the templates above (config/email-templates/ by
 # verify-bundle.yml's auto-commit, screenshots/ by screenshot-templates.yml) —
@@ -28,4 +31,10 @@
 # process), not just template content, so engineering co-owns both.
 /README.md @datum-cloud/gtm @datum-cloud/engineering
 /CONTRIBUTING.md @datum-cloud/gtm @datum-cloud/engineering
-/.github/ISSUE_TEMPLATE/new-template-request.yml @datum-cloud/gtm
+
+# GitHub Issue Form YAML, not prose — the new-template-request AI draft flow
+# reads this form's dropdown id/options directly, so malformed YAML here
+# breaks issue submission for everyone. Engineering co-owns alongside GTM,
+# who still needs to keep the "closest existing" dropdown in sync with the
+# template list.
+/.github/ISSUE_TEMPLATE/new-template-request.yml @datum-cloud/gtm @datum-cloud/engineering

--- a/.github/workflows/claude-feedback.yml
+++ b/.github/workflows/claude-feedback.yml
@@ -1,0 +1,116 @@
+# Lets a maintainer hand Claude direct feedback by mentioning @claude in a
+# comment on either the original request issue or its draft PR, instead of
+# only ever getting one automated first-pass draft. This uses
+# claude-code-action's comment-trigger mode (`trigger_phrase`) rather than the
+# `label_trigger` mode claude-content-request.yml/claude-new-template.yml use:
+# it reads the comment thread for context and checks out the right branch
+# itself (the PR's head branch when triggered from a PR, or by resolving the
+# linked PR when triggered from the original issue), then pushes a follow-up
+# commit onto that same branch and replies inline, rather than opening a new
+# PR.
+#
+# Shared setup mirrors claude-content-request.yml — see that file's comments
+# for why each piece is needed: WIF auth to the Anthropic API (no static
+# ANTHROPIC_API_KEY secret), git/PR operations authenticated as our GitHub App
+# instead of GITHUB_TOKEN (so commits attribute correctly and aren't blocked
+# by GitHub's same-token loop prevention), and pnpm install before Claude
+# starts since it has no network/install access of its own.
+#
+# Restricted to org members/collaborators (not just anyone who can comment on
+# a public repo) via author_association, same as the label-triggered flows'
+# restriction on who can apply `ai-draft`.
+name: Claude feedback on request
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  respond:
+    if: >
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.sender.author_association) &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Mint GitHub App installation token for git/PR operations
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_GH_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_GH_APP_PRIVATE_KEY }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          bot_id: '306493438'
+          bot_name: 'datum-email-designer[bot]'
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          anthropic_workspace_id: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
+          trigger_phrase: '@claude'
+          show_full_output: true
+          claude_args: |
+            --allowedTools "Read,Edit,Bash(pnpm generate:all:*),Bash(pnpm check:*),Bash(git:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue comment:*)"
+          prompt: |
+            A maintainer left feedback mentioning @claude in a comment thread on this
+            repo. Read CLAUDE.md at the repo root first for how the template/bundle
+            pipeline works.
+
+            Figure out which branch to work on:
+            - If you're already checked out on a PR branch (this run was triggered from a
+              comment on a PR, or a PR review), make the change directly on it.
+            - If this was triggered from a comment on the *original request issue* (not a
+              PR), find the draft PR it produced: run `gh pr list --search "Closes #<issue
+              number> in:body" --state open` and check out that PR's head branch before
+              making any change. If no open PR references this issue, reply explaining
+              that you can't find a draft PR to update and stop.
+
+            Once on the right branch:
+            1. Interpret the feedback as a request to adjust the email template(s) this
+               request already touched — wording, spacing, a copy tweak, a variant change,
+               etc. Only make the change the feedback actually asks for; don't take the
+               opportunity to tweak anything else.
+            2. Edit the relevant emails/*.tsx. Only touch emails/components/ or
+               emails/layouts/ if the feedback explicitly calls for a shared-component
+               change, not just this one template.
+            3. Run `pnpm generate:all` to regenerate config/email-templates/ and `pnpm
+               check` to confirm Biome is clean. Include the regenerated output in your
+               commit.
+            4. Commit and push the change onto the existing PR branch — do not open a new
+               PR, do not force-push, do not amend or rewrite any commit already on the
+               branch.
+            5. Reply in the comment thread confirming what changed, in plain language: no
+               file paths, `pnpm`, "regenerated YAML", Biome, or other implementation
+               detail.
+
+            If the feedback is ambiguous, asks for something outside an email template
+            (workflow/script/CI changes, unrelated files), or you can't confidently map it
+            to a specific change, reply asking for clarification instead of guessing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ If you just need wording or content changed on an existing email and aren't comf
 
 For either kind of request opened by a team member, Claude automatically opens a first-pass PR as soon as the issue is opened (see `.github/workflows/claude-content-request.yml` and `.github/workflows/claude-new-template.yml`), with the `datum-cloud/gtm` team requested as reviewer and a screenshot of the rendered template posted as a comment — someone still reviews and merges it like any other PR. This repo is public, so requests from anyone outside the team don't auto-trigger; a maintainer reviews them and adds the `ai-draft` label to run Claude on them. That same label re-triggers a run that failed or fell short, regardless of who opened the issue.
 
+Have feedback on a draft once it's open? A maintainer can reply with `@claude` and what should change — on the request issue or directly on the PR — and Claude pushes a follow-up commit onto that same PR branch (see `.github/workflows/claude-feedback.yml`). This is restricted to maintainers, not open to every commenter on this public repo.
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Need wording changed on an existing email, or a brand-new template entirely? You
 
 If you're a member of the team, Claude automatically drafts a PR as soon as you submit the issue. Anyone else's request is triaged by a maintainer first, who adds the `ai-draft` label to have Claude take a pass at it — that same label re-triggers a run that failed or fell short. Either way, a draft PR still needs human review (copy, brand, and — for new templates — layout) before it merges.
 
+Want something changed on a draft? A maintainer can reply `@claude` with the feedback — on the issue or the PR itself — and Claude pushes a follow-up commit to the same PR.
+
 Once that PR is merged, it's not live for real users yet — see [**"How do I actually release this?"**](./RELEASING.md) for the (no-code) steps to publish it.
 
 ## Contributing


### PR DESCRIPTION
Part of #18.

## Summary

Today `claude-content-request.yml`/`claude-new-template.yml` only fire once, when the request issue is opened (or re-labeled `ai-draft`). Any feedback on the resulting draft — a reviewer wants different wording, a different variant, etc. — has to be fixed by hand; there was no automated way to get Claude to revise the same PR.

This adds `.github/workflows/claude-feedback.yml`: a maintainer can reply `@claude` with feedback on either the original request issue or the draft PR itself, and Claude:
- resolves the right branch (the PR it's already on, or — if commented on the issue — the open PR whose body closes that issue),
- makes the requested template edit,
- regenerates `config/email-templates/` and checks Biome,
- pushes a follow-up commit onto the **same** PR branch (never opens a new PR, never rewrites existing commits),
- replies in plain language confirming what changed.

Restricted to org members/collaborators via `author_association`, same as who's allowed to apply the `ai-draft` label — not open to every commenter on this public repo.

Also updated README.md and CONTRIBUTING.md to mention this to non-technical stakeholders.

## Test plan

- [ ] Open a test content-change-request issue, let Claude draft the PR, then comment `@claude` on the PR asking for a small wording tweak — confirm a follow-up commit lands on the same branch and Biome/generate:all stay clean
- [ ] Comment `@claude` on the *issue* instead (after a draft PR exists) — confirm it finds and updates the linked PR rather than opening a new one
- [ ] Comment `@claude` from a non-maintainer account — confirm the workflow doesn't fire
