### PR TITLE
fix(passkey-email): mark unrendered Browser/Device variables optional

### DIFF
--- a/config/email-templates/userpasskeyadded-emailtemplate.yaml
+++ b/config/email-templates/userpasskeyadded-emailtemplate.yaml
@@ -284,8 +284,8 @@ spec:
     required: true
     type: "string"
   - name: "Browser"
-    required: true
+    required: false
     type: "string"
   - name: "Device"
-    required: true
+    required: false
     type: "string"

--- a/scripts/generate-yaml.js
+++ b/scripts/generate-yaml.js
@@ -194,12 +194,21 @@ function main() {
     const explicitSubject = extractExplicitSubject(tsx);
     const subject = explicitSubject || extractSubjectFromHtml(htmlRepl);
 
-    // Convert PreviewProps to variables format
-    const variables = Object.keys(previewProps).map(key => ({
-      name: key,
-      required: true,
-      type: 'string'
-    }));
+    // Convert PreviewProps to variables format. milo's EmailTemplate
+    // admission webhook rejects any template whose required variable is not
+    // referenced in BOTH htmlBody and textBody (see milo
+    // pkg/email/templating/{html,text}validator.go), and a rejected template
+    // strands Flux on the previous bundle. Variables a template declares but
+    // never renders (declared so producers may still send them) must
+    // therefore be emitted as optional.
+    const variables = Object.keys(previewProps).map((key) => {
+      const ref = `{{.${key}}}`;
+      return {
+        name: key,
+        required: htmlRepl.includes(ref) && textRepl.includes(ref),
+        type: 'string'
+      };
+    });
 
     const yaml = generateYaml({ baseName, subject, html: htmlRepl, text: textRepl, variables });
     const fileName = `${baseName.replace(/-/g, '')}-emailtemplate.yaml`;


### PR DESCRIPTION
## Summary

The PR #82 fix (dropping the empty Browser/Device rows) merged and published fine, but **staging never applied it**: the Flux Kustomization `datum-email-templates-customization` has been in `ReconciliationFailed` since Jul 29, pinned to the Jul 24 bundle (`v0.0.0-main-20260724-023346`) — which is why staging emails still show the empty rows.

**Root cause:** milo's EmailTemplate admission webhook requires every `required: true` variable to be referenced in *both* `htmlBody` and `textBody` (`pkg/email/templating/{html,text}validator.go`). PR #82 removed the `{{.Browser}}`/`{{.Device}}` references, but `scripts/generate-yaml.js` hardcodes `required: true` for every PreviewProps key — so milo rejects the new template and Flux retries forever on the old bundle. Invisible in CI, since the webhook only runs at apply time in-cluster.

**Fix:** the generator now derives each variable's `required` flag from whether the rendered html/text output actually references it. Declared-but-unrendered variables (kept declared because producers still send them, and undeclared sent variables are rejected at send time) are emitted as `required: false`, which milo accepts. This makes the "webhook rejects bundle, Flux silently stuck" failure class impossible by construction.

Bundle diff is exactly the fix: only `Browser`/`Device` flip to `required: false` in `userpasskeyadded-emailtemplate.yaml`; all other templates are byte-identical.

## Test plan

- [x] `pnpm generate:all` with lockfile-pinned deps — only the passkey YAML variables change
- [x] Replicated milo's webhook validation (same regexp, same both-bodies rule) against the bundle: current main's passkey YAML **fails** exactly as staging rejects it; this branch's passes, all 8 templates green
- [ ] After merge: confirm `datum-email-templates-customization` becomes `Ready` and its revision advances to the new `v0.0.0-main-*` tag (OCIRepository polls every 5m, failing Kustomization retries every 2m)
- [ ] Trigger a passkey-added email on staging and confirm the Browser/Device rows are gone

## Related

- Follow-up to #82
- #85 can be closed: its fix half already merged via #82, and its "preload directives" half is regeneration churn from a stale local `node_modules` (react-email 6.5.0 vs lockfile's 6.9.0), not a real change
